### PR TITLE
Loop Tweaks and Pattern Offset

### DIFF
--- a/build/rhombus.js
+++ b/build/rhombus.js
@@ -992,16 +992,14 @@
         //       based on the current playback position
         for (var playlistId in track._playlist) {
           var ptnId   = track._playlist[playlistId]._ptnId;
+          var offset  = track._playlist[playlistId]._start;
           var noteMap = r._song._patterns[ptnId]._noteMap;
-
-          // TODO: Handle note start and end times relative to the start of
-          //       the originating playlist item
 
           // TODO: find a more efficient way to determine which notes to play
           if (r.isPlaying()) {
             for (var noteId in noteMap) {
               var note = noteMap[noteId];
-              var start = note.getStart();
+              var start = note.getStart() + offset;
 
               if (start >= scheduleStart && start < scheduleEnd) {
                 var delay = r.ticks2Seconds(start) - curPos;

--- a/build/rhombus.js
+++ b/build/rhombus.js
@@ -598,12 +598,23 @@
       this._name = "Default Pattern Name";
 
       // pattern structure data
+      this._length = 1920;
       this._noteMap = {};
     };
 
     // TODO: make this interface a little more sanitary...
     //       It's a rather direct as-is
     r.Pattern.prototype = {
+
+      getLength: function() {
+        return this._length;
+      },
+
+      setLength: function(length) {
+        if (length !== undefined && length >= 0)
+          this._length = length;
+      },
+
       addNote: function(note) {
         this._noteMap[note._id] = note;
       },
@@ -863,6 +874,7 @@
         var newPattern = new r.Pattern(pattern._id);
 
         newPattern._name = pattern._name;
+        newPattern._length = pattern._length;
 
         // dumbing down Note (e.g., by removing methods from its
         // prototype) might make deserializing much easier

--- a/build/rhombus.js
+++ b/build/rhombus.js
@@ -1082,6 +1082,7 @@
         return;
       }
 
+      // Flush any notes that might be lingering
       resetPlayback(r.seconds2Ticks(time));
 
       playing = true;
@@ -1108,18 +1109,13 @@
 
     r.loopPlayback = function (nowTicks) {
       var tickDiff = nowTicks - loopEnd;
-      if (tickDiff >= 0) {
-        // Schedule notes at the beginning of the loop
-        lastScheduled = loopStart;
-        r.moveToPositionTicks(loopStart);
-        scheduleNotes();
-      }
-      else {
-        // Adjust the playback position to help mitigate timing drift
-        lastScheduled = loopStart + tickDiff;
-        r.moveToPositionTicks(loopStart + tickDiff);
-        scheduleNotes();
-      }
+
+      if (tickDiff > 0)
+        console.log("tickDIff = " + tickDiff);
+
+      resetPlayback(loopStart + tickDiff);
+      r.moveToPositionTicks(loopStart + tickDiff);
+      scheduleNotes();      
     };
 
     function getPosition(playing) {

--- a/src/rhombus.edit.js
+++ b/src/rhombus.edit.js
@@ -45,6 +45,8 @@
 
       var curTicks = r.seconds2Ticks(r.getPosition());
 
+      // TODO: See note in deleteNote()
+      /*
       for (var trkId in r._song._tracks) {
         var track = r._song._tracks[trkId];
         var playingNotes = track._playingNotes;
@@ -54,6 +56,7 @@
           delete playingNotes[rtNoteId];
         }
       }
+      */
 
       note._start = start;
       note._length = length;

--- a/src/rhombus.pattern.js
+++ b/src/rhombus.pattern.js
@@ -16,12 +16,23 @@
       this._name = "Default Pattern Name";
 
       // pattern structure data
+      this._length = 1920;
       this._noteMap = {};
     };
 
     // TODO: make this interface a little more sanitary...
     //       It's a rather direct as-is
     r.Pattern.prototype = {
+
+      getLength: function() {
+        return this._length;
+      },
+
+      setLength: function(length) {
+        if (length !== undefined && length >= 0)
+          this._length = length;
+      },
+
       addNote: function(note) {
         this._noteMap[note._id] = note;
       },

--- a/src/rhombus.song.js
+++ b/src/rhombus.song.js
@@ -105,6 +105,7 @@
         var newPattern = new r.Pattern(pattern._id);
 
         newPattern._name = pattern._name;
+        newPattern._length = pattern._length;
 
         // dumbing down Note (e.g., by removing methods from its
         // prototype) might make deserializing much easier

--- a/src/rhombus.time.js
+++ b/src/rhombus.time.js
@@ -86,7 +86,7 @@
               var note = noteMap[noteId];
               var start = note.getStart();
 
-              if (start >= scheduleStart && start <= scheduleEnd) {
+              if (start >= scheduleStart && start < scheduleEnd) {
                 var delay = r.ticks2Seconds(start) - curPos;
 
                 var startTime = curTime + delay;
@@ -158,8 +158,6 @@
           delete playingNotes[rtNoteId];
         }
       }
-
-      r.Instrument.killAllNotes();
     }
 
     r.startPlayback = function() {
@@ -167,19 +165,17 @@
         return;
       }
 
+      // Flush any notes that might be lingering
+      resetPlayback(r.seconds2Ticks(time));
+
       playing = true;
-
-      // TODO: song start position needs to be defined somewhere
-
-      // Begin slightly before the start position to prevent
-      // missing notes at the beginning
       r.moveToPositionSeconds(time);
-
       startTime = r._ctx.currentTime;
 
       // Force the first round of scheduling
       scheduleNotes();
 
+      // Restart the worker
       scheduleWorker.postMessage({ playing: true });
     };
 
@@ -196,16 +192,18 @@
 
     r.loopPlayback = function (nowTicks) {
       var tickDiff = nowTicks - loopEnd;
-      if (tickDiff >= 0 && loopEnabled === true) {
+      if (tickDiff >= 0) {
         // Schedule notes at the beginning of the loop
         lastScheduled = loopStart;
         r.moveToPositionTicks(loopStart);
         scheduleNotes();
       }
-
-      // Adjust the playback position to help mitigate timing drift
-      r.moveToPositionTicks(loopStart + tickDiff);
-      scheduleNotes();
+      else {
+        // Adjust the playback position to help mitigate timing drift
+        lastScheduled = loopStart + tickDiff;
+        r.moveToPositionTicks(loopStart + tickDiff);
+        scheduleNotes();
+      }
     };
 
     function getPosition(playing) {
@@ -235,7 +233,6 @@
 
     r.moveToPositionSeconds = function(seconds) {
       if (playing) {
-        resetPlayback(r.seconds2Ticks(seconds));
         time = seconds - r._ctx.currentTime;
       } else {
         time = seconds;

--- a/src/rhombus.time.js
+++ b/src/rhombus.time.js
@@ -75,16 +75,14 @@
         //       based on the current playback position
         for (var playlistId in track._playlist) {
           var ptnId   = track._playlist[playlistId]._ptnId;
+          var offset  = track._playlist[playlistId]._start;
           var noteMap = r._song._patterns[ptnId]._noteMap;
-
-          // TODO: Handle note start and end times relative to the start of
-          //       the originating playlist item
 
           // TODO: find a more efficient way to determine which notes to play
           if (r.isPlaying()) {
             for (var noteId in noteMap) {
               var note = noteMap[noteId];
-              var start = note.getStart();
+              var start = note.getStart() + offset;
 
               if (start >= scheduleStart && start < scheduleEnd) {
                 var delay = r.ticks2Seconds(start) - curPos;

--- a/src/rhombus.time.js
+++ b/src/rhombus.time.js
@@ -18,7 +18,7 @@
         "}\n" +
         "function triggerSchedule() {\n" +
         "  postMessage(0);\n" +
-        "  scheduleId = setTimeout(triggerSchedule, 10);\n" +
+        "  scheduleId = setTimeout(triggerSchedule, 5);\n" +
         "}\n";
       var blob = new Blob([code], {type: "application/javascript"});
       return new Worker(URL.createObjectURL(blob));
@@ -28,12 +28,13 @@
     scheduleWorker.onmessage = scheduleNotes;
 
     // Number of seconds to schedule ahead
-    var scheduleAhead = 0.030;
+    var scheduleAhead = 0.050;
     var lastScheduled = -1;
 
     // TODO: scheduling needs to happen relative to that start time of the
     // pattern
     function scheduleNotes() {
+
       // capturing the current time and position so that all scheduling actions
       // in this time frame are on the same "page," so to speak
       var curTime = r.getElapsedTime();
@@ -57,7 +58,7 @@
         var playingNotes = track._playingNotes;
 
         // Schedule note-offs for notes playing on the current track.
-        // Do this before schedyling note-ons to prevent back-to-back notes from
+        // Do this before scheduling note-ons to prevent back-to-back notes from
         // interfering with each other.
         for (var rtNoteId in playingNotes) {
           var rtNote = playingNotes[rtNoteId];
@@ -65,7 +66,6 @@
 
           if (end <= scheduleEndTime) {
             var delay = end - curTime;
-
             r.Instrument.triggerRelease(rtNote._id, delay);
             delete playingNotes[rtNoteId];
           }
@@ -78,7 +78,7 @@
           var noteMap = r._song._patterns[ptnId]._noteMap;
 
           // TODO: Handle note start and end times relative to the start of
-          //       the originating pattern
+          //       the originating playlist item
 
           // TODO: find a more efficient way to determine which notes to play
           if (r.isPlaying()) {
@@ -149,6 +149,8 @@
     function resetPlayback(resetPoint) {
       lastScheduled = resetPoint;
 
+      scheduleWorker.postMessage({ playing: false });
+
       for (var trkId in r._song._tracks) {
         var track = r._song._tracks[trkId];
         var playingNotes = track._playingNotes;
@@ -158,6 +160,8 @@
           delete playingNotes[rtNoteId];
         }
       }
+
+      scheduleWorker.postMessage({ playing: true });
     }
 
     r.startPlayback = function() {
@@ -192,9 +196,16 @@
 
     r.loopPlayback = function (nowTicks) {
       var tickDiff = nowTicks - loopEnd;
+
+      if (tickDiff > 0) {
+        console.log("[Rhomb] Loopback missed loop start by " + tickDiff + " ticks");
+        resetPlayback(loopStart);
+        r.moveToPositionTicks(loopStart);
+      }
+
       resetPlayback(loopStart + tickDiff);
       r.moveToPositionTicks(loopStart + tickDiff);
-      scheduleNotes();      
+      scheduleNotes();
     };
 
     function getPosition(playing) {

--- a/src/rhombus.time.js
+++ b/src/rhombus.time.js
@@ -192,18 +192,9 @@
 
     r.loopPlayback = function (nowTicks) {
       var tickDiff = nowTicks - loopEnd;
-      if (tickDiff >= 0) {
-        // Schedule notes at the beginning of the loop
-        lastScheduled = loopStart;
-        r.moveToPositionTicks(loopStart);
-        scheduleNotes();
-      }
-      else {
-        // Adjust the playback position to help mitigate timing drift
-        lastScheduled = loopStart + tickDiff;
-        r.moveToPositionTicks(loopStart + tickDiff);
-        scheduleNotes();
-      }
+      resetPlayback(loopStart + tickDiff);
+      r.moveToPositionTicks(loopStart + tickDiff);
+      scheduleNotes();      
     };
 
     function getPosition(playing) {


### PR DESCRIPTION
I've fiddled with note scheduling a bit in an attempt to minimize the chances of notes being missed if there is a spike in CPU activity (e.g., due to a lot of GUI activity) at the moment playback is wrapping around. My attempts have been largely successful, but finding a more robust solution (if one exists) will have to wait for later.

I also made the minor change needed to support track playlist items which are offset from the origin. I've tested it minimally and it seems to work as expected.