### PR TITLE
More Instrument Routing Changes

### DIFF
--- a/build/rhombus.js
+++ b/build/rhombus.js
@@ -14,6 +14,7 @@
     this._active = true;
     this._disposed = false;
     this._ctx = Tone.context;
+    this._globalTarget = 0;
 
     this.setActive = function(active) {
       if (this._disposed) {
@@ -34,6 +35,10 @@
       }
     };
 
+    this.setGlobalTarget = function(target) {
+      console.log("[Rhomb] setting global target to " + target);
+      this._globalTarget = +target;
+    };
 
     // This run-time ID is used for IDs that don't need to be exported/imported
     // with the song (e.g., RtNotes)
@@ -918,7 +923,7 @@
     var dbDisplay = Rhombus._map.dbDisplay;
     var rawDisplay = Rhombus._map.rawDisplay;
     var hzDisplay = Rhombus._map.hzDisplay;
-    
+
     var monoSynthMap = {
       "portamento" : [Rhombus._map.mapLinear(0, 10), secondsDisplay, 0],
       "volume" : [Rhombus._map.mapLog(-96.32, 0), dbDisplay, 0.1],
@@ -1068,17 +1073,28 @@
       }
     }
     r.buf = buffer;
-
-    
     // HACK: end
 
-    // only one preview note is allowed at a time
-    var previewNote = undefined;
+    getInstIdByIndex = function(instrIdx) {
+      var keys = [];
+      for (var k in r._song._instruments) {
+        keys.push(k);
+      }
+
+      var instId = keys[instrIdx];
+      return instId;
+    };
 
     r.setParameter = function(paramIdx, value) {
-      for (var instId in r._song._instruments) {
-        r._song._instruments[instId].normalizedSet(paramIdx, value);
+      var inst = r._song._instruments[getInstIdByIndex(r._globalTarget)];
+
+      if (typeof inst === "undefined") {
+        console.log("[Rhomb] - Trying to set parameter on undefined instrument -- dame dayo!");
+        return undefined;
       }
+
+      inst.normalizedSet(paramIdx, value);
+      return value;
     };
 
     r.setParameterByName = function(paramName, value) {
@@ -1087,6 +1103,8 @@
       }
     }
 
+    // only one preview note is allowed at a time
+    var previewNote = undefined;
     r.startPreviewNote = function(pitch) {
       var keys = Object.keys(r._song._instruments);
       if (keys.length === 0) {
@@ -1094,8 +1112,14 @@
       }
 
       if (previewNote === undefined) {
-        previewNote = new Note(pitch, 0);
-        r._song._instruments[keys[0]].triggerAttack(previewNote._id, pitch, 0);
+        var inst = r._song._instruments[getInstIdByIndex(r._globalTarget)];
+        if (typeof inst === "undefined") {
+          console.log("[Rhomb] - Trying to trigger note on undefined instrument");
+          return;
+        }
+
+        previewNote = new r.RtNote(pitch, 0);
+        inst.triggerAttack(previewNote._id, pitch, 0);
       }
     };
 
@@ -1106,7 +1130,13 @@
       }
 
       if (previewNote !== undefined) {
-        r._song._instruments[keys[0]].triggerRelease(previewNote._id, 0);
+        var inst = r._song._instruments[getInstIdByIndex(r._globalTarget)];
+        if (typeof inst === "undefined") {
+          console.log("[Rhomb] - Trying to release note on undefined instrument");
+          return;
+        }
+
+        inst.triggerRelease(previewNote._id, 0);
         previewNote = undefined;
       }
     };
@@ -1608,13 +1638,13 @@
           // TODO: find a more robust way to terminate playing notes
           for (var rtNoteId in this._playingNotes) {
             var note = this._playingNotes[rtNoteId];
-            r._song._instruments[track._target].triggerRelease(rtNoteId, 0); 
+            r._song._instruments[track._target].triggerRelease(rtNoteId, 0);
             delete this._playingNotes[rtNoteId];
           }
 
           // TODO: Figure out why this doesn't work
           //r.removeInstrument(track._target);
-          
+
           delete this._instruments[track._target];
           delete this._tracks[trkId];
           return trkId;
@@ -1829,7 +1859,7 @@
               var start = note.getStart() + itemStart;
 
               if (start >= scheduleStart &&
-                  start < scheduleEnd && 
+                  start < scheduleEnd &&
                   start < itemEnd) {
                 var delay = r.ticks2Seconds(start) - curPos;
 
@@ -1838,7 +1868,7 @@
 
                 var rtNote = new r.RtNote(note._pitch, startTime, endTime);
                 playingNotes[rtNote._id] = rtNote;
-                
+
                 r._song._instruments[track._target].triggerAttack(rtNote._id, note.getPitch(), delay);
               }
             }

--- a/build/rhombus.js
+++ b/build/rhombus.js
@@ -1112,13 +1112,14 @@
       }
 
       if (previewNote === undefined) {
-        var inst = r._song._instruments[getInstIdByIndex(r._globalTarget)];
+        var targetId = getInstIdByIndex(r._globalTarget);
+        var inst = r._song._instruments[targetId];
         if (typeof inst === "undefined") {
           console.log("[Rhomb] - Trying to trigger note on undefined instrument");
           return;
         }
 
-        previewNote = new r.RtNote(pitch, 0);
+        previewNote = new r.RtNote(pitch, 0, 0, targetId);
         inst.triggerAttack(previewNote._id, pitch, 0);
       }
     };
@@ -1130,7 +1131,7 @@
       }
 
       if (previewNote !== undefined) {
-        var inst = r._song._instruments[getInstIdByIndex(r._globalTarget)];
+        var inst = r._song._instruments[previewNote._target];
         if (typeof inst === "undefined") {
           console.log("[Rhomb] - Trying to release note on undefined instrument");
           return;
@@ -1427,11 +1428,12 @@
       }
     };
 
-    r.RtNote = function(pitch, start, end) {
+    r.RtNote = function(pitch, start, end, target) {
       r._newRtId(this);
       this._pitch = pitch || 60;
       this._start = start || 0;
       this._end = end || 0;
+      this._target = target;
     };
 
     r.Track = function(id) {
@@ -1833,7 +1835,7 @@
 
           if (end <= scheduleEndTime) {
             var delay = end - curTime;
-            r._song._instruments[track._target].triggerRelease(rtNote._id, delay);
+            r._song._instruments[rtNote._target].triggerRelease(rtNote._id, delay);
             delete playingNotes[rtNoteId];
           }
         }
@@ -1866,7 +1868,7 @@
                 var startTime = curTime + delay;
                 var endTime = startTime + r.ticks2Seconds(note._length);
 
-                var rtNote = new r.RtNote(note._pitch, startTime, endTime);
+                var rtNote = new r.RtNote(note._pitch, startTime, endTime, track._target);
                 playingNotes[rtNote._id] = rtNote;
 
                 r._song._instruments[track._target].triggerAttack(rtNote._id, note.getPitch(), delay);

--- a/src/rhombus.header.js
+++ b/src/rhombus.header.js
@@ -14,6 +14,7 @@
     this._active = true;
     this._disposed = false;
     this._ctx = Tone.context;
+    this._globalTarget = 0;
 
     this.setActive = function(active) {
       if (this._disposed) {
@@ -34,6 +35,10 @@
       }
     };
 
+    this.setGlobalTarget = function(target) {
+      console.log("[Rhomb] setting global target to " + target);
+      this._globalTarget = +target;
+    };
 
     // This run-time ID is used for IDs that don't need to be exported/imported
     // with the song (e.g., RtNotes)

--- a/src/rhombus.instrument.js
+++ b/src/rhombus.instrument.js
@@ -322,13 +322,14 @@
       }
 
       if (previewNote === undefined) {
-        var inst = r._song._instruments[getInstIdByIndex(r._globalTarget)];
+        var targetId = getInstIdByIndex(r._globalTarget);
+        var inst = r._song._instruments[targetId];
         if (typeof inst === "undefined") {
           console.log("[Rhomb] - Trying to trigger note on undefined instrument");
           return;
         }
 
-        previewNote = new r.RtNote(pitch, 0);
+        previewNote = new r.RtNote(pitch, 0, 0, targetId);
         inst.triggerAttack(previewNote._id, pitch, 0);
       }
     };
@@ -340,7 +341,7 @@
       }
 
       if (previewNote !== undefined) {
-        var inst = r._song._instruments[getInstIdByIndex(r._globalTarget)];
+        var inst = r._song._instruments[previewNote._target];
         if (typeof inst === "undefined") {
           console.log("[Rhomb] - Trying to release note on undefined instrument");
           return;

--- a/src/rhombus.instrument.js
+++ b/src/rhombus.instrument.js
@@ -283,17 +283,28 @@
       }
     }
     r.buf = buffer;
-
-
     // HACK: end
 
-    // only one preview note is allowed at a time
-    var previewNote = undefined;
+    getInstIdByIndex = function(instrIdx) {
+      var keys = [];
+      for (var k in r._song._instruments) {
+        keys.push(k);
+      }
+
+      var instId = keys[instrIdx];
+      return instId;
+    };
 
     r.setParameter = function(paramIdx, value) {
-      for (var instId in r._song._instruments) {
-        r._song._instruments[instId].normalizedSet(paramIdx, value);
+      var inst = r._song._instruments[getInstIdByIndex(r._globalTarget)];
+
+      if (typeof inst === "undefined") {
+        console.log("[Rhomb] - Trying to set parameter on undefined instrument -- dame dayo!");
+        return undefined;
       }
+
+      inst.normalizedSet(paramIdx, value);
+      return value;
     };
 
     r.setParameterByName = function(paramName, value) {
@@ -302,6 +313,8 @@
       }
     }
 
+    // only one preview note is allowed at a time
+    var previewNote = undefined;
     r.startPreviewNote = function(pitch) {
       var keys = Object.keys(r._song._instruments);
       if (keys.length === 0) {
@@ -309,8 +322,14 @@
       }
 
       if (previewNote === undefined) {
-        previewNote = new Note(pitch, 0);
-        r._song._instruments[keys[0]].triggerAttack(previewNote._id, pitch, 0);
+        var inst = r._song._instruments[getInstIdByIndex(r._globalTarget)];
+        if (typeof inst === "undefined") {
+          console.log("[Rhomb] - Trying to trigger note on undefined instrument");
+          return;
+        }
+
+        previewNote = new r.RtNote(pitch, 0);
+        inst.triggerAttack(previewNote._id, pitch, 0);
       }
     };
 
@@ -321,7 +340,13 @@
       }
 
       if (previewNote !== undefined) {
-        r._song._instruments[keys[0]].triggerRelease(previewNote._id, 0);
+        var inst = r._song._instruments[getInstIdByIndex(r._globalTarget)];
+        if (typeof inst === "undefined") {
+          console.log("[Rhomb] - Trying to release note on undefined instrument");
+          return;
+        }
+
+        inst.triggerRelease(previewNote._id, 0);
         previewNote = undefined;
       }
     };

--- a/src/rhombus.instrument.js
+++ b/src/rhombus.instrument.js
@@ -133,7 +133,7 @@
     var dbDisplay = Rhombus._map.dbDisplay;
     var rawDisplay = Rhombus._map.rawDisplay;
     var hzDisplay = Rhombus._map.hzDisplay;
-    
+
     var monoSynthMap = {
       "portamento" : [Rhombus._map.mapLinear(0, 10), secondsDisplay, 0],
       "volume" : [Rhombus._map.mapLog(-96.32, 0), dbDisplay, 0.1],
@@ -284,8 +284,7 @@
     }
     r.buf = buffer;
 
-    var instrId = r.addInstrument("mono");
-    r._song._instruments[instrId].normalizedObjectSet({ volume: 0.1 });
+
     // HACK: end
 
     // only one preview note is allowed at a time

--- a/src/rhombus.song.js
+++ b/src/rhombus.song.js
@@ -71,8 +71,16 @@
       },
 
       addTrack: function() {
+        // Create a new Track object
         var track = new r.Track();
         this._tracks[track._id] = track;
+
+        // Create a new Instrument and set it as the new Track's target
+        var instrId = r.addInstrument("mono");
+        r._song._instruments[instrId].normalizedObjectSet({ volume: 0.1 });
+        track._target = instrId;
+
+        // Return the ID of the new Track
         return track._id;
       },
 
@@ -86,14 +94,14 @@
           // TODO: find a more robust way to terminate playing notes
           for (var rtNoteId in this._playingNotes) {
             var note = this._playingNotes[rtNoteId];
-
-            for (var instId in r._song._instruments) {
-              r._song._instruments[instId].triggerRelease(rtNoteId, 0);
-            }
-
+            r._song._instruments[track._target].triggerRelease(rtNoteId, 0);
             delete this._playingNotes[rtNoteId];
           }
 
+          // TODO: Figure out why this doesn't work
+          //r.removeInstrument(track._target);
+
+          delete this._instruments[track._target];
           delete this._tracks[trkId];
           return trkId;
         }
@@ -169,6 +177,7 @@
         var newTrack = new r.Track(track._id);
 
         newTrack._name = track._name;
+        newTrack._target = +track._target;
 
         for (var itemId in playlist) {
           var item = playlist[itemId];
@@ -185,7 +194,7 @@
 
       for (var instId in instruments) {
         var inst = instruments[instId];
-        var instId = r.addInstrument(inst._type, inst._params, +instId);
+        r.addInstrument(inst._type, inst._params, +instId);
         r._song._instruments[instId].normalizedObjectSet({ volume: 0.1 });
       }
 

--- a/src/rhombus.time.js
+++ b/src/rhombus.time.js
@@ -64,10 +64,7 @@
 
           if (end <= scheduleEndTime) {
             var delay = end - curTime;
-            
-            for (var instId in r._song._instruments) {
-              r._song._instruments[instId].triggerRelease(rtNote._id, delay);
-            }
+            r._song._instruments[track._target].triggerRelease(rtNote._id, delay);
             delete playingNotes[rtNoteId];
           }
         }
@@ -93,7 +90,7 @@
               var start = note.getStart() + itemStart;
 
               if (start >= scheduleStart &&
-                  start < scheduleEnd && 
+                  start < scheduleEnd &&
                   start < itemEnd) {
                 var delay = r.ticks2Seconds(start) - curPos;
 
@@ -103,9 +100,7 @@
                 var rtNote = new r.RtNote(note._pitch, startTime, endTime);
                 playingNotes[rtNote._id] = rtNote;
 
-                for (var instId in r._song._instruments) {
-                  r._song._instruments[instId].triggerAttack(rtNote._id, note.getPitch(), delay);
-                }
+                r._song._instruments[track._target].triggerAttack(rtNote._id, note.getPitch(), delay);
               }
             }
           }

--- a/src/rhombus.time.js
+++ b/src/rhombus.time.js
@@ -64,7 +64,7 @@
 
           if (end <= scheduleEndTime) {
             var delay = end - curTime;
-            r._song._instruments[track._target].triggerRelease(rtNote._id, delay);
+            r._song._instruments[rtNote._target].triggerRelease(rtNote._id, delay);
             delete playingNotes[rtNoteId];
           }
         }
@@ -97,7 +97,7 @@
                 var startTime = curTime + delay;
                 var endTime = startTime + r.ticks2Seconds(note._length);
 
-                var rtNote = new r.RtNote(note._pitch, startTime, endTime);
+                var rtNote = new r.RtNote(note._pitch, startTime, endTime, track._target);
                 playingNotes[rtNote._id] = rtNote;
 
                 r._song._instruments[track._target].triggerAttack(rtNote._id, note.getPitch(), delay);

--- a/src/rhombus.track.js
+++ b/src/rhombus.track.js
@@ -73,7 +73,7 @@
       this._name = "Default Track Name";
 
       // track structure data
-      this._targets = {};
+      this._target = undefined;
       this._playingNotes = {};
 
       // TODO: define some kind of pattern playlist
@@ -162,7 +162,7 @@
         var toReturn = {};
         toReturn._id = this._id;
         toReturn._name = this._name;
-        toReturn._targets = this._targets;
+        toReturn._target = this._target;
         toReturn._playlist = this._playlist;
         return toReturn;
       }

--- a/src/rhombus.track.js
+++ b/src/rhombus.track.js
@@ -55,11 +55,12 @@
       }
     };
 
-    r.RtNote = function(pitch, start, end) {
+    r.RtNote = function(pitch, start, end, target) {
       r._newRtId(this);
       this._pitch = pitch || 60;
       this._start = start || 0;
       this._end = end || 0;
+      this._target = target;
     };
 
     r.Track = function(id) {


### PR DESCRIPTION
I've made it so that a new instrument is created for each track, and that instrument is the track's sole target. The the instrument is deleted when the track is removed. I also added a "global target," which is the instrument that parameter changes and preview notes from the pattern editor will apply to.

It's a big pile of hacks, but it's something to get us started. I've modified the music app to make use of the changes. Good times.