### PR TITLE
Added array-of-ids interface for tracks and instruments

### DIFF
--- a/build/rhombus.js
+++ b/build/rhombus.js
@@ -104,6 +104,14 @@
     return typeof obj === "undefined";
   };
 
+  window.isNumber = function(obj) {
+    return typeof obj === "number";
+  }
+
+  window.notNumber = function(obj) {
+    return typeof obj !== "number";
+  }
+
   window.isNull = function(obj) {
     return obj === null;
   };
@@ -111,7 +119,6 @@
   window.notNull = function(obj) {
     return obj !== null;
   };
-
 
   function calculator(noteNum) {
     return Math.pow(2, (noteNum-69)/12) * 440;
@@ -126,6 +133,101 @@
   Rhombus.Util.noteNum2Freq = function(noteNum) {
     return table[noteNum];
   }
+
+  function IdSlotContainer(slotCount) {
+    this._slots = [];
+    this._map = {};
+    this._count = slotCount;
+  }
+
+  IdSlotContainer.prototype.getById = function(id) {
+    if (id in this._map) {
+      return this._map[id];
+    } else {
+      return undefined;
+    }
+  };
+
+  function firstEmptySlot(isc, idx) {
+    if (notNumber(idx)) {
+      idx = 0;
+    }
+
+    for (var i = idx; i < (isc._count + idx); i++) {
+      var realI = i % isc._count;
+      if (isUndefined(isc._slots[realI])) {
+        return realI;
+      }
+    }
+
+    return -1;
+  }
+
+  IdSlotContainer.prototype.addObject = function(obj, idx) {
+    var id = obj._id;
+    if (id in this._map) {
+      return undefined;
+    }
+
+    var idx = firstEmptySlot(this, idx);
+    if (idx < 0) {
+      return undefined;
+    }
+
+    this._slots[idx] = id;
+    this._map[id] = obj;
+    return obj;
+  };
+
+  IdSlotContainer.prototype.removeId = function(id) {
+    if (!(id in this._map)) {
+      return;
+    }
+
+    for (var idx = 0; idx < this._count; idx++) {
+      if (this._slots[idx] === id) {
+        this._slots[idx] = undefined;
+      }
+    }
+
+    var toRet = this._map[id];
+    delete this._map[id];
+    return toRet;
+  };
+
+  IdSlotContainer.prototype.removeObj = function(obj) {
+    return this.removeId(obj._id);
+  };
+
+  IdSlotContainer.prototype.getIdBySlot = function(idx) {
+    if (idx >= 0 && idx < this._count) {
+      return this._slots[idx];
+    } else {
+      return undefined;
+    }
+  };
+
+  IdSlotContainer.prototype.getObjBySlot = function(idx) {
+    return this.getObjById(this.getIdBySlot(idx));
+  };
+
+  IdSlotContainer.prototype.getObjById = function(id) {
+    return this._map[id];
+  }
+
+  IdSlotContainer.prototype.swapSlots = function(idx1, idx2) {
+    if (idx1 >= 0 && idx1 < this._count && idx2 >= 0 && idx2 < this._count) {
+      var from1 = this._slots[idx1];
+      this._slots[idx1] = this._slots[idx2];
+      this._slots[idx2] = from1;
+    }
+  };
+
+  IdSlotContainer.prototype.isFull = function() {
+    return firstEmptySlot(this) == -1;
+  };
+
+  Rhombus.Util.IdSlotContainer = IdSlotContainer;
 
   Rhombus._map = {};
 

--- a/build/rhombus.js
+++ b/build/rhombus.js
@@ -1405,7 +1405,7 @@
   Rhombus._patternSetup = function(r) {
 
     r.Pattern = function(id) {
-      if (id) {
+      if (isDefined(id)) {
         r._setId(this, id);
       } else {
         r._newId(this);

--- a/build/rhombus.js
+++ b/build/rhombus.js
@@ -1503,7 +1503,7 @@
   Rhombus._trackSetup = function(r) {
 
     r.PlaylistItem = function(ptnId, start, length, id) {
-      if (id) {
+      if (isDefined(id)) {
         r._setId(this, id);
       } else {
         r._newId(this);

--- a/build/rhombus.js
+++ b/build/rhombus.js
@@ -1687,7 +1687,7 @@
       this._loopEnd   = 1920;
 
       // song structure data
-      this._tracks = {};
+      this._tracks = new Rhombus.Util.IdSlotContainer(16);
       this._patterns = {};
       this._instruments = new Rhombus.Util.IdSlotContainer(16);
       this._effects = {};
@@ -1748,7 +1748,7 @@
       addTrack: function() {
         // Create a new Track object
         var track = new r.Track();
-        this._tracks[track._id] = track;
+        this._tracks.addObj(track);
 
         // Create a new Instrument and set it as the new Track's target
         var instrId = r.addInstrument("mono");
@@ -1760,7 +1760,7 @@
       },
 
       deleteTrack: function(trkId) {
-        var track = this._tracks[trkId];
+        var track = this._tracks.getObjById(trkId);
 
         if (notDefined(track)) {
           return undefined;
@@ -1777,7 +1777,7 @@
           //r.removeInstrument(track._target);
 
           this._instruments.removeId(track._target);
-          delete this._tracks[trkId];
+          this._tracks.deleteId(trkId);
           return trkId;
         }
       },
@@ -1787,8 +1787,8 @@
       findSongLength: function() {
         var length = 0;
 
-        for (var trkId in this._tracks) {
-          var track = this._tracks[trkId];
+        this._tracks.objIds().forEach(function(trkId) {
+          var track = this._tracks.getObjById(trkId);
 
           for (var itemId in track._playlist) {
             var item = track._playlist[itemId];
@@ -1798,7 +1798,7 @@
               length = itemEnd;
             }
           }
-        }
+        });
 
         return length;
       }
@@ -1868,7 +1868,7 @@
           newTrack._playlist[+itemId] = newItem;
         }
 
-        r._song._tracks[+trkId] = newTrack;
+        r._song._tracks.addObj(newTrack);
       }
 
       for (var instId in instruments) {
@@ -1957,8 +1957,8 @@
       var scheduleEndTime = curTime + scheduleAhead;
 
       // Iterate over every track to find notes that can be scheduled
-      for (var trkId in r._song._tracks) {
-        var track = r._song._tracks[trkId];
+      r._song._tracks.objIds().forEach(function(trkId) {
+        var track = r._song._tracks.getObjById(trkId);
         var playingNotes = track._playingNotes;
 
         // Schedule note-offs for notes playing on the current track.
@@ -2015,7 +2015,7 @@
             }
           }
         }
-      }
+      });
 
       lastScheduled = scheduleEnd;
 
@@ -2078,8 +2078,8 @@
     var loopEnabled = false;
 
     r.killAllNotes = function() {
-      for (var trkId in r._song._tracks) {
-        var track = r._song._tracks[trkId];
+      r._song._tracks.objIds().forEach(function(trkId) {
+        var track = r._song._tracks.getObjById(trkId);
         var playingNotes = track._playingNotes;
 
         for (var rtNoteId in playingNotes) {
@@ -2088,7 +2088,7 @@
           });
           delete playingNotes[rtNoteId];
         }
-      }
+      });
     };
 
     r.startPlayback = function() {
@@ -2251,15 +2251,15 @@
       //       as things stand, deleted notes will stop playing
       //       naturally, but not when the pattern note is deleted
       /*
-      for (var trkId in r._song._tracks) {
-        var track = r._song._tracks[trkId];
+      r._song._tracks.objIds().forEach(function(trkId) {
+        var track = r._song._tracks.getObjById(trkId);
         var playingNotes = track._playingNotes;
 
         if (noteId in playingNotes) {
           r.Instrument.triggerRelease(rtNoteId, 0);
           delete playingNotes[rtNoteId];
         }
-      }
+      });
       */
     };
 
@@ -2274,15 +2274,15 @@
 
       // TODO: See note in deleteNote()
       /*
-      for (var trkId in r._song._tracks) {
-        var track = r._song._tracks[trkId];
+      r._song._tracks.objIds().forEach(function(trkId) {
+        var track = r._song._tracks.getObjById(trkId);
         var playingNotes = track._playingNotes;
 
         if (rtNoteId in playingNotes) {
           r.Instrument.triggerRelease(rtNoteId, 0);
           delete playingNotes[rtNoteId];
         }
-      }
+      });
       */
 
       note._start = start;

--- a/build/rhombus.js
+++ b/build/rhombus.js
@@ -958,7 +958,7 @@
     }
     Tone.extend(Instrument, Tone.PolySynth);
 
-    r.addInstrument = function(type, options, id) {
+    r.addInstrument = function(type, options, id, idx) {
       var instr;
       if (type === "samp") {
         instr = new r._Sampler(options, id);
@@ -970,7 +970,7 @@
         return;
       }
 
-      r._song._instruments.addObj(instr);
+      r._song._instruments.addObj(instr, idx);
       return instr._id;
     };
 
@@ -1786,9 +1786,10 @@
       // playlist item on any track
       findSongLength: function() {
         var length = 0;
+        var thisSong = this;
 
         this._tracks.objIds().forEach(function(trkId) {
-          var track = this._tracks.getObjById(trkId);
+          var track = thisSong._tracks.getObjById(trkId);
 
           for (var itemId in track._playlist) {
             var item = track._playlist[itemId];
@@ -1849,8 +1850,9 @@
         r._song._patterns[+ptnId] = newPattern;
       }
 
-      for (var trkId in tracks) {
-        var track = tracks[trkId];
+      for (var trkIdIdx in tracks._slots) {
+        var trkId = tracks._slots[trkIdIdx];
+        var track = tracks._map[trkId];
         var playlist = track._playlist;
 
         var newTrack = new r.Track(track._id);
@@ -1868,13 +1870,14 @@
           newTrack._playlist[+itemId] = newItem;
         }
 
-        r._song._tracks.addObj(newTrack);
+        r._song._tracks.addObj(newTrack, trkIdIdx);
       }
 
-      for (var instId in instruments) {
-        var inst = instruments[instId];
-        r.addInstrument(inst._type, inst._params, +instId);
-        r._song._instruments.getObjbyId(instId).normalizedObjectSet({ volume: 0.1 });
+      for (var instIdIdx in instruments._slots) {
+        var instId = instruments._slots[instIdIdx];
+        var inst = instruments._map[instId];
+        r.addInstrument(inst.type, inst.params, +instId, instIdIdx);
+        r._song._instruments.getObjById(instId).normalizedObjectSet({ volume: 0.1 });
       }
 
       for (var effId in effects) {

--- a/demos/timebase-demo.html
+++ b/demos/timebase-demo.html
@@ -15,7 +15,7 @@ function ins(a, b, c) {
   rhomb.Edit.insertNote(new rhomb.Note(a, b, c), patId);
 }
 var trackId = rhomb._song.addTrack();
-rhomb._song._tracks[trackId].addToPlaylist(patId, 0, 3840);
+rhomb._song._tracks.getObjById(trackId).addToPlaylist(patId, 0, 3840);
 
 ins(60, 0, 240);
 ins(63, 240, 240);

--- a/src/rhombus.edit.js
+++ b/src/rhombus.edit.js
@@ -10,9 +10,9 @@
       var curTicks = r.seconds2Ticks(r.getPosition());
       var playing = note.getStart() <= curTicks && curTicks <= note.getEnd();
       if (playing) {
-        for (var instId in r._song._instruments) {
-          r._song._instruments[instId].triggerRelease(rtNoteId, 0);
-        }
+        r._song._instruments.objIds().forEach(function(instId) {
+          r._song._instruments.getObjById(instId).triggerRelease(rtNoteId, 0);
+        });
       }
     }
 
@@ -76,9 +76,9 @@
         return;
       }
 
-      for (var instId in r._song._instruments) {
-        r._song._instruments[instId].triggerRelease(rtNoteId, 0);
-      }
+      r._song._instruments.objIds().forEach(function(instId) {
+        r._song._instruments.getObjById(instId).triggerRelease(rtNoteId, 0);
+      });
       note._pitch = pitch;
     };
 

--- a/src/rhombus.edit.js
+++ b/src/rhombus.edit.js
@@ -27,15 +27,15 @@
       //       as things stand, deleted notes will stop playing
       //       naturally, but not when the pattern note is deleted
       /*
-      for (var trkId in r._song._tracks) {
-        var track = r._song._tracks[trkId];
+      r._song._tracks.objIds().forEach(function(trkId) {
+        var track = r._song._tracks.getObjById(trkId);
         var playingNotes = track._playingNotes;
 
         if (noteId in playingNotes) {
           r.Instrument.triggerRelease(rtNoteId, 0);
           delete playingNotes[rtNoteId];
         }
-      }
+      });
       */
     };
 
@@ -50,15 +50,15 @@
 
       // TODO: See note in deleteNote()
       /*
-      for (var trkId in r._song._tracks) {
-        var track = r._song._tracks[trkId];
+      r._song._tracks.objIds().forEach(function(trkId) {
+        var track = r._song._tracks.getObjById(trkId);
         var playingNotes = track._playingNotes;
 
         if (rtNoteId in playingNotes) {
           r.Instrument.triggerRelease(rtNoteId, 0);
           delete playingNotes[rtNoteId];
         }
-      }
+      });
       */
 
       note._start = start;

--- a/src/rhombus.instrument.js
+++ b/src/rhombus.instrument.js
@@ -57,7 +57,7 @@
         return;
       }
 
-      r._song._instruments[instr._id] = instr;
+      r._song._instruments.addObj(instr);
       return instr._id;
     };
 
@@ -77,7 +77,7 @@
         return;
       }
 
-      delete r._song._instruments[id];
+      r._song._instruments.removeId(id);
     };
 
     Instrument.prototype.triggerAttack = function(id, pitch, delay) {
@@ -287,16 +287,16 @@
 
     getInstIdByIndex = function(instrIdx) {
       var keys = [];
-      for (var k in r._song._instruments) {
+      r._song._instruments.objIds().forEach(function(k) {
         keys.push(k);
-      }
+      });
 
       var instId = keys[instrIdx];
       return instId;
     };
 
     r.setParameter = function(paramIdx, value) {
-      var inst = r._song._instruments[getInstIdByIndex(r._globalTarget)];
+      var inst = r._song._instruments.getObjById(getInstIdByIndex(r._globalTarget));
 
       if (notDefined(inst)) {
         console.log("[Rhomb] - Trying to set parameter on undefined instrument -- dame dayo!");
@@ -308,22 +308,22 @@
     };
 
     r.setParameterByName = function(paramName, value) {
-      for (var instId in r._song._instruments) {
-        r._song._instruments[instId].normalizedSetByName(paramName, value);
-      }
+      r._song._instruments.objIds().forEach(function(instId) {
+        r._song._instruments.getObjById(instId).normalizedSetByName(paramName, value);
+      });
     }
 
     // only one preview note is allowed at a time
     var previewNote = undefined;
     r.startPreviewNote = function(pitch) {
-      var keys = Object.keys(r._song._instruments);
+      var keys = r._song._instruments.objIds();
       if (keys.length === 0) {
         return;
       }
 
       if (notDefined(previewNote)) {
         var targetId = getInstIdByIndex(r._globalTarget);
-        var inst = r._song._instruments[targetId];
+        var inst = r._song._instruments.getObjById(targetId);
         if (notDefined(inst)) {
           console.log("[Rhomb] - Trying to trigger note on undefined instrument");
           return;
@@ -335,13 +335,13 @@
     };
 
     r.stopPreviewNote = function() {
-      var keys = Object.keys(r._song._instruments);
+      var keys = r._song._instruments.objIds();
       if (keys.length === 0) {
         return;
       }
 
       if (isDefined(previewNote)) {
-        var inst = r._song._instruments[previewNote._target];
+        var inst = r._song._instruments.getObjById(previewNote._target);
         if (notDefined(inst)) {
           console.log("[Rhomb] - Trying to release note on undefined instrument");
           return;

--- a/src/rhombus.instrument.js
+++ b/src/rhombus.instrument.js
@@ -45,7 +45,7 @@
     }
     Tone.extend(Instrument, Tone.PolySynth);
 
-    r.addInstrument = function(type, options, id) {
+    r.addInstrument = function(type, options, id, idx) {
       var instr;
       if (type === "samp") {
         instr = new r._Sampler(options, id);
@@ -57,7 +57,7 @@
         return;
       }
 
-      r._song._instruments.addObj(instr);
+      r._song._instruments.addObj(instr, idx);
       return instr._id;
     };
 

--- a/src/rhombus.pattern.js
+++ b/src/rhombus.pattern.js
@@ -6,7 +6,7 @@
   Rhombus._patternSetup = function(r) {
 
     r.Pattern = function(id) {
-      if (id) {
+      if (isDefined(id)) {
         r._setId(this, id);
       } else {
         r._newId(this);

--- a/src/rhombus.song.js
+++ b/src/rhombus.song.js
@@ -16,7 +16,7 @@
       this._loopEnd   = 1920;
 
       // song structure data
-      this._tracks = {};
+      this._tracks = new Rhombus.Util.IdSlotContainer(16);
       this._patterns = {};
       this._instruments = new Rhombus.Util.IdSlotContainer(16);
       this._effects = {};
@@ -77,7 +77,7 @@
       addTrack: function() {
         // Create a new Track object
         var track = new r.Track();
-        this._tracks[track._id] = track;
+        this._tracks.addObj(track);
 
         // Create a new Instrument and set it as the new Track's target
         var instrId = r.addInstrument("mono");
@@ -89,7 +89,7 @@
       },
 
       deleteTrack: function(trkId) {
-        var track = this._tracks[trkId];
+        var track = this._tracks.getObjById(trkId);
 
         if (notDefined(track)) {
           return undefined;
@@ -106,7 +106,7 @@
           //r.removeInstrument(track._target);
 
           this._instruments.removeId(track._target);
-          delete this._tracks[trkId];
+          this._tracks.deleteId(trkId);
           return trkId;
         }
       },
@@ -116,8 +116,8 @@
       findSongLength: function() {
         var length = 0;
 
-        for (var trkId in this._tracks) {
-          var track = this._tracks[trkId];
+        this._tracks.objIds().forEach(function(trkId) {
+          var track = this._tracks.getObjById(trkId);
 
           for (var itemId in track._playlist) {
             var item = track._playlist[itemId];
@@ -127,7 +127,7 @@
               length = itemEnd;
             }
           }
-        }
+        });
 
         return length;
       }
@@ -197,7 +197,7 @@
           newTrack._playlist[+itemId] = newItem;
         }
 
-        r._song._tracks[+trkId] = newTrack;
+        r._song._tracks.addObj(newTrack);
       }
 
       for (var instId in instruments) {

--- a/src/rhombus.song.js
+++ b/src/rhombus.song.js
@@ -18,7 +18,7 @@
       // song structure data
       this._tracks = {};
       this._patterns = {};
-      this._instruments = {};
+      this._instruments = new Rhombus.Util.IdSlotContainer(16);
       this._effects = {};
 
       this._curId = 0;
@@ -81,7 +81,7 @@
 
         // Create a new Instrument and set it as the new Track's target
         var instrId = r.addInstrument("mono");
-        r._song._instruments[instrId].normalizedObjectSet({ volume: 0.1 });
+        r._song._instruments.getObjById(instrId).normalizedObjectSet({ volume: 0.1 });
         track._target = instrId;
 
         // Return the ID of the new Track
@@ -98,14 +98,14 @@
           // TODO: find a more robust way to terminate playing notes
           for (var rtNoteId in this._playingNotes) {
             var note = this._playingNotes[rtNoteId];
-            r._song._instruments[track._target].triggerRelease(rtNoteId, 0);
+            r._song._instruments.getObjById(track._target).triggerRelease(rtNoteId, 0);
             delete this._playingNotes[rtNoteId];
           }
 
           // TODO: Figure out why this doesn't work
           //r.removeInstrument(track._target);
 
-          delete this._instruments[track._target];
+          this._instruments.removeId(track._target);
           delete this._tracks[trkId];
           return trkId;
         }
@@ -203,7 +203,7 @@
       for (var instId in instruments) {
         var inst = instruments[instId];
         r.addInstrument(inst._type, inst._params, +instId);
-        r._song._instruments[instId].normalizedObjectSet({ volume: 0.1 });
+        r._song._instruments.getObjbyId(instId).normalizedObjectSet({ volume: 0.1 });
       }
 
       for (var effId in effects) {

--- a/src/rhombus.song.js
+++ b/src/rhombus.song.js
@@ -115,9 +115,10 @@
       // playlist item on any track
       findSongLength: function() {
         var length = 0;
+        var thisSong = this;
 
         this._tracks.objIds().forEach(function(trkId) {
-          var track = this._tracks.getObjById(trkId);
+          var track = thisSong._tracks.getObjById(trkId);
 
           for (var itemId in track._playlist) {
             var item = track._playlist[itemId];
@@ -178,8 +179,9 @@
         r._song._patterns[+ptnId] = newPattern;
       }
 
-      for (var trkId in tracks) {
-        var track = tracks[trkId];
+      for (var trkIdIdx in tracks._slots) {
+        var trkId = tracks._slots[trkIdIdx];
+        var track = tracks._map[trkId];
         var playlist = track._playlist;
 
         var newTrack = new r.Track(track._id);
@@ -197,13 +199,14 @@
           newTrack._playlist[+itemId] = newItem;
         }
 
-        r._song._tracks.addObj(newTrack);
+        r._song._tracks.addObj(newTrack, trkIdIdx);
       }
 
-      for (var instId in instruments) {
-        var inst = instruments[instId];
-        r.addInstrument(inst._type, inst._params, +instId);
-        r._song._instruments.getObjbyId(instId).normalizedObjectSet({ volume: 0.1 });
+      for (var instIdIdx in instruments._slots) {
+        var instId = instruments._slots[instIdIdx];
+        var inst = instruments._map[instId];
+        r.addInstrument(inst.type, inst.params, +instId, instIdIdx);
+        r._song._instruments.getObjById(instId).normalizedObjectSet({ volume: 0.1 });
       }
 
       for (var effId in effects) {

--- a/src/rhombus.time.js
+++ b/src/rhombus.time.js
@@ -66,7 +66,7 @@
 
           if (end <= scheduleEndTime) {
             var delay = end - curTime;
-            r._song._instruments[rtNote._target].triggerRelease(rtNote._id, delay);
+            r._song._instruments.getObjById(rtNote._target).triggerRelease(rtNote._id, delay);
             delete playingNotes[rtNoteId];
           }
         }
@@ -106,7 +106,7 @@
                 var rtNote = new r.RtNote(note._pitch, startTime, endTime, track._target);
                 playingNotes[rtNote._id] = rtNote;
 
-                r._song._instruments[track._target].triggerAttack(rtNote._id, note.getPitch(), delay);
+                r._song._instruments.getObjById(track._target).triggerAttack(rtNote._id, note.getPitch(), delay);
               }
             }
           }
@@ -179,9 +179,9 @@
         var playingNotes = track._playingNotes;
 
         for (var rtNoteId in playingNotes) {
-          for (var instId in r._song._instruments) {
-            r._song._instruments[instId].triggerRelease(rtNoteId, 0);
-          }
+          r._song._instruments.objIds().forEach(function(instId) {
+            r._song._instruments.getObjById(instId).triggerRelease(rtNoteId, 0);
+          });
           delete playingNotes[rtNoteId];
         }
       }

--- a/src/rhombus.time.js
+++ b/src/rhombus.time.js
@@ -53,8 +53,8 @@
       var scheduleEndTime = curTime + scheduleAhead;
 
       // Iterate over every track to find notes that can be scheduled
-      for (var trkId in r._song._tracks) {
-        var track = r._song._tracks[trkId];
+      r._song._tracks.objIds().forEach(function(trkId) {
+        var track = r._song._tracks.getObjById(trkId);
         var playingNotes = track._playingNotes;
 
         // Schedule note-offs for notes playing on the current track.
@@ -111,7 +111,7 @@
             }
           }
         }
-      }
+      });
 
       lastScheduled = scheduleEnd;
 
@@ -174,8 +174,8 @@
     var loopEnabled = false;
 
     r.killAllNotes = function() {
-      for (var trkId in r._song._tracks) {
-        var track = r._song._tracks[trkId];
+      r._song._tracks.objIds().forEach(function(trkId) {
+        var track = r._song._tracks.getObjById(trkId);
         var playingNotes = track._playingNotes;
 
         for (var rtNoteId in playingNotes) {
@@ -184,7 +184,7 @@
           });
           delete playingNotes[rtNoteId];
         }
-      }
+      });
     };
 
     r.startPlayback = function() {

--- a/src/rhombus.track.js
+++ b/src/rhombus.track.js
@@ -7,7 +7,7 @@
   Rhombus._trackSetup = function(r) {
 
     r.PlaylistItem = function(ptnId, start, length, id) {
-      if (id) {
+      if (isDefined(id)) {
         r._setId(this, id);
       } else {
         r._newId(this);

--- a/src/rhombus.util.js
+++ b/src/rhombus.util.js
@@ -14,6 +14,14 @@
     return typeof obj === "undefined";
   };
 
+  window.isNumber = function(obj) {
+    return typeof obj === "number";
+  }
+
+  window.notNumber = function(obj) {
+    return typeof obj !== "number";
+  }
+
   window.isNull = function(obj) {
     return obj === null;
   };
@@ -21,7 +29,6 @@
   window.notNull = function(obj) {
     return obj !== null;
   };
-
 
   function calculator(noteNum) {
     return Math.pow(2, (noteNum-69)/12) * 440;
@@ -36,6 +43,101 @@
   Rhombus.Util.noteNum2Freq = function(noteNum) {
     return table[noteNum];
   }
+
+  function IdSlotContainer(slotCount) {
+    this._slots = [];
+    this._map = {};
+    this._count = slotCount;
+  }
+
+  IdSlotContainer.prototype.getById = function(id) {
+    if (id in this._map) {
+      return this._map[id];
+    } else {
+      return undefined;
+    }
+  };
+
+  function firstEmptySlot(isc, idx) {
+    if (notNumber(idx)) {
+      idx = 0;
+    }
+
+    for (var i = idx; i < (isc._count + idx); i++) {
+      var realI = i % isc._count;
+      if (isUndefined(isc._slots[realI])) {
+        return realI;
+      }
+    }
+
+    return -1;
+  }
+
+  IdSlotContainer.prototype.addObject = function(obj, idx) {
+    var id = obj._id;
+    if (id in this._map) {
+      return undefined;
+    }
+
+    var idx = firstEmptySlot(this, idx);
+    if (idx < 0) {
+      return undefined;
+    }
+
+    this._slots[idx] = id;
+    this._map[id] = obj;
+    return obj;
+  };
+
+  IdSlotContainer.prototype.removeId = function(id) {
+    if (!(id in this._map)) {
+      return;
+    }
+
+    for (var idx = 0; idx < this._count; idx++) {
+      if (this._slots[idx] === id) {
+        this._slots[idx] = undefined;
+      }
+    }
+
+    var toRet = this._map[id];
+    delete this._map[id];
+    return toRet;
+  };
+
+  IdSlotContainer.prototype.removeObj = function(obj) {
+    return this.removeId(obj._id);
+  };
+
+  IdSlotContainer.prototype.getIdBySlot = function(idx) {
+    if (idx >= 0 && idx < this._count) {
+      return this._slots[idx];
+    } else {
+      return undefined;
+    }
+  };
+
+  IdSlotContainer.prototype.getObjBySlot = function(idx) {
+    return this.getObjById(this.getIdBySlot(idx));
+  };
+
+  IdSlotContainer.prototype.getObjById = function(id) {
+    return this._map[id];
+  }
+
+  IdSlotContainer.prototype.swapSlots = function(idx1, idx2) {
+    if (idx1 >= 0 && idx1 < this._count && idx2 >= 0 && idx2 < this._count) {
+      var from1 = this._slots[idx1];
+      this._slots[idx1] = this._slots[idx2];
+      this._slots[idx2] = from1;
+    }
+  };
+
+  IdSlotContainer.prototype.isFull = function() {
+    return firstEmptySlot(this) == -1;
+  };
+
+  Rhombus.Util.IdSlotContainer = IdSlotContainer;
 
   Rhombus._map = {};
 

--- a/src/rhombus.util.js
+++ b/src/rhombus.util.js
@@ -65,7 +65,7 @@
 
     for (var i = idx; i < (isc._count + idx); i++) {
       var realI = i % isc._count;
-      if (isUndefined(isc._slots[realI])) {
+      if (notDefined(isc._slots[realI])) {
         return realI;
       }
     }
@@ -73,7 +73,7 @@
     return -1;
   }
 
-  IdSlotContainer.prototype.addObject = function(obj, idx) {
+  IdSlotContainer.prototype.addObj = function(obj, idx) {
     var id = obj._id;
     if (id in this._map) {
       return undefined;
@@ -135,6 +135,10 @@
 
   IdSlotContainer.prototype.isFull = function() {
     return firstEmptySlot(this) == -1;
+  };
+
+  IdSlotContainer.prototype.objIds = function() {
+    return Object.keys(this._map);
   };
 
   Rhombus.Util.IdSlotContainer = IdSlotContainer;


### PR DESCRIPTION
The code for the array-of-ids interface is reusable, so it's fairly easy to convert anything from the old "plain old ID map" format to this "array of ids + id map" format. Just have to remember to fix up the import code and any code that directly accesses the old maps.