### PR TITLE
Loop Override

### DIFF
--- a/build/rhombus.js
+++ b/build/rhombus.js
@@ -2376,6 +2376,13 @@
     var scheduleAhead = 0.050;
     var lastScheduled = -1;
 
+    var playing = false;
+    var time = 0;
+    var startTime = 0;
+
+    var loopEnabled = false;
+    var loopOverride = false;
+
     function scheduleNotes() {
 
       // capturing the current time and position so that all scheduling actions
@@ -2388,7 +2395,8 @@
       var loopEnd = r.getLoopEnd();
 
       // Determine if playback needs to loop around in this time window
-      var doWrap = r.getLoopEnabled() && (r.getLoopEnd() - nowTicks < aheadTicks);
+      var doWrap = (!loopOverride && r.getLoopEnabled()) && 
+        (r.getLoopEnd() - nowTicks < aheadTicks);
 
       var scheduleStart = lastScheduled;
       var scheduleEnd = (doWrap) ? r.getLoopEnd() : nowTicks + aheadTicks;
@@ -2526,16 +2534,6 @@
       return this._song._bpm;
     }
 
-    var playing = false;
-    var time = 0;
-    var startTime = 0;
-
-    // Loop start and end position in ticks, default is one measure
-    //var loopStart   = 0;
-    //var loopEnd     = 1920;
-    var loopEnabled = false;
-    var loopOverride = false;
-
     r.killAllNotes = function() {
       var thisr = this;
       thisr._song._tracks.objIds().forEach(function(trkId) {
@@ -2622,13 +2620,11 @@
       var seconds = this.ticks2Seconds(ticks);
       this.moveToPositionSeconds(seconds);
 
-      if ((loopEnabled || loopOverride) && ticks > r.getLoopEnd()) {
-        loopEnabled = false;
+      if (loopEnabled && ticks > r.getLoopEnd()) {
         loopOverride = true;
       }
 
       if (ticks < r.getLoopEnd() && loopOverride) {
-        loopEnabled = true;
         loopOverride = false;
       }
     };
@@ -2647,6 +2643,15 @@
 
     r.setLoopEnabled = function(enabled) {
       loopEnabled = enabled;
+
+      var ticks = r.seconds2Ticks(r.getPosition());
+      if (loopEnabled && ticks > r.getLoopEnd()) {
+        loopOverride = true;
+      }
+
+      if (ticks < r.getLoopEnd() && loopOverride) {
+        loopOverride = false;
+      }
     };
 
     r.getLoopStart = function() {
@@ -2681,6 +2686,13 @@
         console.log("[Rhombus] - Invalid loop range");
         return undefined;
       }
+
+      var curPos = r.seconds2Ticks(r.getPosition());
+
+      if (curPos < this._song._loopEnd && curPos > end) {
+        r.moveToPositionTicks(end);
+      }
+      
       this._song._loopEnd = end;
       return this._song._loopEnd;
     };

--- a/build/rhombus.js
+++ b/build/rhombus.js
@@ -1676,6 +1676,7 @@
 
       // pattern metadata
       this._name = "Default Pattern Name";
+      this._color = "#6666AA";
 
       // pattern structure data
       this._length = 1920;
@@ -1714,6 +1715,15 @@
 
           return this._name;
         }
+      },
+
+      // TODO: validate this color stuff
+      getColor: function() {
+        return this._color;
+      },
+
+      setColor: function(color) {
+        this._color = color;
       },
 
       addNote: function(note) {
@@ -2260,6 +2270,10 @@
 
         newPattern._name = pattern._name;
         newPattern._length = pattern._length;
+
+        if (isDefined(pattern._color)) {
+          newPattern.setColor(pattern._color);
+        }
 
         // dumbing down Note (e.g., by removing methods from its
         // prototype) might make deserializing much easier

--- a/build/rhombus.js
+++ b/build/rhombus.js
@@ -2534,6 +2534,7 @@
     //var loopStart   = 0;
     //var loopEnd     = 1920;
     var loopEnabled = false;
+    var loopOverride = false;
 
     r.killAllNotes = function() {
       var thisr = this;
@@ -2620,6 +2621,16 @@
       lastScheduled = ticks;
       var seconds = this.ticks2Seconds(ticks);
       this.moveToPositionSeconds(seconds);
+
+      if ((loopEnabled || loopOverride) && ticks > r.getLoopEnd()) {
+        loopEnabled = false;
+        loopOverride = true;
+      }
+
+      if (ticks < r.getLoopEnd() && loopOverride) {
+        loopEnabled = true;
+        loopOverride = false;
+      }
     };
 
     r.moveToPositionSeconds = function(seconds) {

--- a/src/rhombus.pattern.js
+++ b/src/rhombus.pattern.js
@@ -14,6 +14,7 @@
 
       // pattern metadata
       this._name = "Default Pattern Name";
+      this._color = "#6666AA";
 
       // pattern structure data
       this._length = 1920;
@@ -52,6 +53,15 @@
 
           return this._name;
         }
+      },
+
+      // TODO: validate this color stuff
+      getColor: function() {
+        return this._color;
+      },
+
+      setColor: function(color) {
+        this._color = color;
       },
 
       addNote: function(note) {

--- a/src/rhombus.song.js
+++ b/src/rhombus.song.js
@@ -206,6 +206,10 @@
         newPattern._name = pattern._name;
         newPattern._length = pattern._length;
 
+        if (isDefined(pattern._color)) {
+          newPattern.setColor(pattern._color);
+        }
+
         // dumbing down Note (e.g., by removing methods from its
         // prototype) might make deserializing much easier
         for (var noteId in noteMap) {

--- a/src/rhombus.time.js
+++ b/src/rhombus.time.js
@@ -189,6 +189,7 @@
     //var loopStart   = 0;
     //var loopEnd     = 1920;
     var loopEnabled = false;
+    var loopOverride = false;
 
     r.killAllNotes = function() {
       var thisr = this;
@@ -275,6 +276,16 @@
       lastScheduled = ticks;
       var seconds = this.ticks2Seconds(ticks);
       this.moveToPositionSeconds(seconds);
+
+      if ((loopEnabled || loopOverride) && ticks > r.getLoopEnd()) {
+        loopEnabled = false;
+        loopOverride = true;
+      }
+
+      if (ticks < r.getLoopEnd() && loopOverride) {
+        loopEnabled = true;
+        loopOverride = false;
+      }
     };
 
     r.moveToPositionSeconds = function(seconds) {


### PR DESCRIPTION
Previously, when loop was enabled, playback was constrained to the loop range. I have modified it so that if the position is manually moved outside of the loop range, looping is overridden for scheduling purposes. Overriding is disabled once the playback position is moved back into the loop range. 

These changes are intended to make manually seeking around easier in the music application.