### PR TITLE
MIDI Input

### DIFF
--- a/build/rhombus.js
+++ b/build/rhombus.js
@@ -1403,9 +1403,7 @@
         velocity = 0.5;
       }
 
-      console.log("[Rhombus] - starting preview note at tick " +
-                  this.getCurrentPosTicks());
-
+      // TODO: clean up all this time business
       var rtNote = new this.RtNote(pitch,
                                    velocity,
                                    this.getElapsedTime(),
@@ -1438,11 +1436,6 @@
           inst.triggerRelease(rtNote._id, 0);
           previewNotes.splice(i, 1);
 
-          var length = this.seconds2Ticks(curTime - rtNote._startTime);
-          console.log("[Rhombus] - stopping preview note at tick " + curTicks +
-                      ", length = " + length + " ticks");
-
-          // TODO: buffer stopped preview notes for recording purposes
           if (this.isPlaying() && this.getRecordEnabled()) {
             this.Record.addToBuffer(rtNote._pitch,
                                     rtNote._velocity,
@@ -2812,11 +2805,11 @@
 
     r.RtNote = function(pitch, velocity, start, end, target, startTime) {
       r._newRtId(this);
-      this._pitch = pitch || 60;
-      this._velocity = +velocity || 0.5;
-      this._start = start || 0;
-      this._end = end || 0;
-      this._target = target;
+      this._pitch     = (isNaN(pitch) || notDefined(pitch)) ? 60 : pitch;
+      this._velocity  = +velocity || 0.5;
+      this._start     = start || 0;
+      this._end       = end || 0;
+      this._target    = target;
       this._startTime = startTime;
 
       return this;

--- a/build/rhombus.js
+++ b/build/rhombus.js
@@ -96,6 +96,9 @@
     root.Rhombus._timeSetup(this);
     root.Rhombus._editSetup(this);
 
+    // MIDI
+    root.Rhombus._midiSetup(this);
+
     this.initSong();
   };
 
@@ -4173,5 +4176,83 @@
     r.Record.clearBuffer = function() {
       recordBuffer.splice(0, recordBuffer.length);
     };
+  };
+})(this.Rhombus);
+
+//! rhombus.effect.midi.js
+//! authors: Spencer Phippen, Tim Grant
+//! license: MIT
+(function(Rhombus) {
+  Rhombus._midiSetup = function(r) {
+
+    var midi = null;  // global MIDIAccess object
+    var inputMap = {};
+
+    function printMidiMessage(event) {
+      var str = "MIDI message received at timestamp " + event.timestamp + "[" + event.data.length + " bytes]: ";
+      for (var i=0; i<event.data.length; i++) {
+        str += "0x" + event.data[i].toString(16) + " ";
+      }
+      console.log(str);
+    }
+
+    function onMidiMessage(event) {
+
+      //printMidiMessage(event);
+
+      // only handle well-formed notes for now (don't worry about running status, etc.)
+      if (event.data.length !== 3) {
+        console.log("[MidiIn] - ignoring MIDI message");
+        return;
+      }
+
+      // parse the message bytes
+      var cmd   = event.data[0] & 0xF0;
+      var chan  = event.data[0] & 0x0F;
+      var pitch = event.data[1];
+      var vel   = event.data[2];
+
+      // check for note-off messages
+      if (cmd === 0x80 || (cmd === 0x90 && vel === 0)) {
+        console.log("[MidiIn] - Note-Off, pitch: " + pitch + "; velocity: " + vel.toFixed(2));
+        rhomb.stopPreviewNote(pitch);
+      }
+
+      // check for note-on messages
+      else if (cmd === 0x90 && vel > 0) {
+        vel /= 127;
+        console.log("[MidiIn] - Note-On, pitch: " + pitch + "; velocity: " + vel.toFixed(2));
+        rhomb.startPreviewNote(pitch, vel);
+      }
+
+      // don't worry about other message types for now
+    }
+
+    function mapMidiInputs(midi) {
+      var it = midi.inputs.entries();
+      for (var entry = it.next(); !entry.done; entry = it.next()) {
+        var value = entry.value;
+        console.log("[MidiIn] - mapping entry " + value[0]);
+        inputMap[value[0]] = value[1];
+        value[1].onmidimessage = onMidiMessage;
+      }
+    }
+
+    function onMidiSuccess(midiAccess) {
+      console.log("MIDI ready!");
+      midi = midiAccess;
+      mapMidiInputs(midi);
+    }
+
+    function onMidiFailure(msg) {
+      console.log( "Failed to get MIDI access - " + msg );
+    }
+
+    r.getMidiAccess = function() {
+      var midi = null;
+      if (typeof navigator.requestMIDIAccess !== "undefined") {
+        navigator.requestMIDIAccess().then(onMidiSuccess, onMidiFailure);
+      }
+    }
   };
 })(this.Rhombus);

--- a/build/rhombus.js
+++ b/build/rhombus.js
@@ -100,6 +100,7 @@
     root.Rhombus._midiSetup(this);
 
     this.initSong();
+    this.getMidiAccess();
   };
 
 })(this);
@@ -4185,8 +4186,9 @@
 (function(Rhombus) {
   Rhombus._midiSetup = function(r) {
 
-    var midi = null;  // global MIDIAccess object
-    var inputMap = {};
+    // MIDI access object
+    r._midi = null;
+    r._inputMap = {};
 
     function printMidiMessage(event) {
       var str = "MIDI message received at timestamp " + event.timestamp + "[" + event.data.length + " bytes]: ";
@@ -4197,7 +4199,6 @@
     }
 
     function onMidiMessage(event) {
-
       //printMidiMessage(event);
 
       // only handle well-formed notes for now (don't worry about running status, etc.)
@@ -4229,19 +4230,20 @@
     }
 
     function mapMidiInputs(midi) {
+      r._inputMap = {};
       var it = midi.inputs.entries();
       for (var entry = it.next(); !entry.done; entry = it.next()) {
         var value = entry.value;
         console.log("[MidiIn] - mapping entry " + value[0]);
-        inputMap[value[0]] = value[1];
+        r._inputMap[value[0]] = value[1];
         value[1].onmidimessage = onMidiMessage;
       }
     }
 
     function onMidiSuccess(midiAccess) {
-      console.log("MIDI ready!");
-      midi = midiAccess;
-      mapMidiInputs(midi);
+      console.log("[Rhombus] - MIDI Access Successful");
+      r._midi = midiAccess;
+      mapMidiInputs(r._midi);
     }
 
     function onMidiFailure(msg) {
@@ -4249,7 +4251,7 @@
     }
 
     r.getMidiAccess = function() {
-      var midi = null;
+      r._midi = null;
       if (typeof navigator.requestMIDIAccess !== "undefined") {
         navigator.requestMIDIAccess().then(onMidiSuccess, onMidiFailure);
       }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,6 +23,7 @@ gulp.task("make", function() {
     "src/rhombus.edit.js",
     "src/rhombus.undo.js",
     "src/rhombus.record.js",
+    "src/rhombus.midi.js",
     ])
     .pipe(concat("rhombus.js"))
     .pipe(gulp.dest("build"))

--- a/src/rhombus.header.js
+++ b/src/rhombus.header.js
@@ -100,6 +100,7 @@
     root.Rhombus._midiSetup(this);
 
     this.initSong();
+    this.getMidiAccess();
   };
 
 })(this);

--- a/src/rhombus.header.js
+++ b/src/rhombus.header.js
@@ -96,6 +96,9 @@
     root.Rhombus._timeSetup(this);
     root.Rhombus._editSetup(this);
 
+    // MIDI
+    root.Rhombus._midiSetup(this);
+
     this.initSong();
   };
 

--- a/src/rhombus.instrument.js
+++ b/src/rhombus.instrument.js
@@ -161,9 +161,7 @@
         velocity = 0.5;
       }
 
-      console.log("[Rhombus] - starting preview note at tick " +
-                  this.getCurrentPosTicks());
-
+      // TODO: clean up all this time business
       var rtNote = new this.RtNote(pitch,
                                    velocity,
                                    this.getElapsedTime(),
@@ -196,11 +194,6 @@
           inst.triggerRelease(rtNote._id, 0);
           previewNotes.splice(i, 1);
 
-          var length = this.seconds2Ticks(curTime - rtNote._startTime);
-          console.log("[Rhombus] - stopping preview note at tick " + curTicks +
-                      ", length = " + length + " ticks");
-
-          // TODO: buffer stopped preview notes for recording purposes
           if (this.isPlaying() && this.getRecordEnabled()) {
             this.Record.addToBuffer(rtNote._pitch,
                                     rtNote._velocity,

--- a/src/rhombus.midi.js
+++ b/src/rhombus.midi.js
@@ -1,0 +1,77 @@
+//! rhombus.effect.midi.js
+//! authors: Spencer Phippen, Tim Grant
+//! license: MIT
+(function(Rhombus) {
+  Rhombus._midiSetup = function(r) {
+
+    var midi = null;  // global MIDIAccess object
+    var inputMap = {};
+
+    function printMidiMessage(event) {
+      var str = "MIDI message received at timestamp " + event.timestamp + "[" + event.data.length + " bytes]: ";
+      for (var i=0; i<event.data.length; i++) {
+        str += "0x" + event.data[i].toString(16) + " ";
+      }
+      console.log(str);
+    }
+
+    function onMidiMessage(event) {
+
+      //printMidiMessage(event);
+
+      // only handle well-formed notes for now (don't worry about running status, etc.)
+      if (event.data.length !== 3) {
+        console.log("[MidiIn] - ignoring MIDI message");
+        return;
+      }
+
+      // parse the message bytes
+      var cmd   = event.data[0] & 0xF0;
+      var chan  = event.data[0] & 0x0F;
+      var pitch = event.data[1];
+      var vel   = event.data[2];
+
+      // check for note-off messages
+      if (cmd === 0x80 || (cmd === 0x90 && vel === 0)) {
+        console.log("[MidiIn] - Note-Off, pitch: " + pitch + "; velocity: " + vel.toFixed(2));
+        rhomb.stopPreviewNote(pitch);
+      }
+
+      // check for note-on messages
+      else if (cmd === 0x90 && vel > 0) {
+        vel /= 127;
+        console.log("[MidiIn] - Note-On, pitch: " + pitch + "; velocity: " + vel.toFixed(2));
+        rhomb.startPreviewNote(pitch, vel);
+      }
+
+      // don't worry about other message types for now
+    }
+
+    function mapMidiInputs(midi) {
+      var it = midi.inputs.entries();
+      for (var entry = it.next(); !entry.done; entry = it.next()) {
+        var value = entry.value;
+        console.log("[MidiIn] - mapping entry " + value[0]);
+        inputMap[value[0]] = value[1];
+        value[1].onmidimessage = onMidiMessage;
+      }
+    }
+
+    function onMidiSuccess(midiAccess) {
+      console.log("MIDI ready!");
+      midi = midiAccess;
+      mapMidiInputs(midi);
+    }
+
+    function onMidiFailure(msg) {
+      console.log( "Failed to get MIDI access - " + msg );
+    }
+
+    r.getMidiAccess = function() {
+      var midi = null;
+      if (typeof navigator.requestMIDIAccess !== "undefined") {
+        navigator.requestMIDIAccess().then(onMidiSuccess, onMidiFailure);
+      }
+    }
+  };
+})(this.Rhombus);

--- a/src/rhombus.midi.js
+++ b/src/rhombus.midi.js
@@ -4,8 +4,9 @@
 (function(Rhombus) {
   Rhombus._midiSetup = function(r) {
 
-    var midi = null;  // global MIDIAccess object
-    var inputMap = {};
+    // MIDI access object
+    r._midi = null;
+    r._inputMap = {};
 
     function printMidiMessage(event) {
       var str = "MIDI message received at timestamp " + event.timestamp + "[" + event.data.length + " bytes]: ";
@@ -16,7 +17,6 @@
     }
 
     function onMidiMessage(event) {
-
       //printMidiMessage(event);
 
       // only handle well-formed notes for now (don't worry about running status, etc.)
@@ -48,19 +48,20 @@
     }
 
     function mapMidiInputs(midi) {
+      r._inputMap = {};
       var it = midi.inputs.entries();
       for (var entry = it.next(); !entry.done; entry = it.next()) {
         var value = entry.value;
         console.log("[MidiIn] - mapping entry " + value[0]);
-        inputMap[value[0]] = value[1];
+        r._inputMap[value[0]] = value[1];
         value[1].onmidimessage = onMidiMessage;
       }
     }
 
     function onMidiSuccess(midiAccess) {
-      console.log("MIDI ready!");
-      midi = midiAccess;
-      mapMidiInputs(midi);
+      console.log("[Rhombus] - MIDI Access Successful");
+      r._midi = midiAccess;
+      mapMidiInputs(r._midi);
     }
 
     function onMidiFailure(msg) {
@@ -68,7 +69,7 @@
     }
 
     r.getMidiAccess = function() {
-      var midi = null;
+      r._midi = null;
       if (typeof navigator.requestMIDIAccess !== "undefined") {
         navigator.requestMIDIAccess().then(onMidiSuccess, onMidiFailure);
       }

--- a/src/rhombus.track.js
+++ b/src/rhombus.track.js
@@ -78,11 +78,11 @@
 
     r.RtNote = function(pitch, velocity, start, end, target, startTime) {
       r._newRtId(this);
-      this._pitch = pitch || 60;
-      this._velocity = +velocity || 0.5;
-      this._start = start || 0;
-      this._end = end || 0;
-      this._target = target;
+      this._pitch     = (isNaN(pitch) || notDefined(pitch)) ? 60 : pitch;
+      this._velocity  = +velocity || 0.5;
+      this._start     = start || 0;
+      this._end       = end || 0;
+      this._target    = target;
       this._startTime = startTime;
 
       return this;


### PR DESCRIPTION
I have added support for MIDI input. Rhombus will accept input from any MIDI interface available to Web MIDI. There is currently no distinction made between different devices or channels. All notes are handled through the preview note interface, and are therefore routed to the global target.

This is only supported in Chrome, and it must be enabled in chrome://flags, since it's an experimental feature.
