### PR TITLE
Moved tracks to graph interface

### DIFF
--- a/build/rhombus.js
+++ b/build/rhombus.js
@@ -77,6 +77,7 @@
     root.Rhombus._songSetup(this);
     root.Rhombus._paramSetup(this);
     root.Rhombus._recordSetup(this);
+    root.Rhombus._audioNodeSetup(this);
 
     // Instruments
     root.Rhombus._instrumentSetup(this);
@@ -975,13 +976,7 @@
       outputObj.to.push(new Port(b._id, bInput));
       inputObj.from.push(new Port(this._id, output));
 
-      // TODO: use the slots when connecting
-      var type = outputObj.type;
-      if (type === "audio") {
-        this.connect(b);
-      } else if (type === "control") {
-        // TODO: implement control routing
-      }
+      this._internalGraphConnect(output, b, bInput);
       return true;
     };
 
@@ -1028,21 +1023,7 @@
       outputObj.to.splice(outputPortIdx, 1);
       inputObj.from.splice(inputPortIdx, 1);
 
-      // TODO: use the slots when disconnecting
-      var type = outputObj.type;
-      if (type === "audio") {
-        // TODO: this should be replaced in such a way that we
-        // don't break all the outgoing connections every time we
-        // disconnect from one thing. Put gain nodes in the middle
-        // or something.
-        this.disconnect();
-        var that = this;
-        outputObj.to.forEach(function (port) {
-          that.connect(graphLookup(port.node));
-        });
-      } else if (type === "control") {
-        // TODO: implement control routing
-      }
+      this._internalGraphDisconnect(output, b, bInput);
     }
 
     function graphX() {
@@ -1518,9 +1499,11 @@
       for (var i = previewNotes.length - 1; i >=0; i--) {
         var rtNote = previewNotes[i];
         if (rtNote._pitch === pitch) {
-          var inst = this._song._instruments.getObjById(rtNote._target);
-
-          if (isDefined(inst)) {
+          for (var targetIdx = 0; targetIdx < rtNote._targets.length; targetIdx++) {
+            var inst = this._song._instruments.getObjById(rtNote._targets[targetIdx]);
+            if (notDefined(inst)) {
+              continue;
+            }
             inst.triggerRelease(rtNote._id, 0);
           }
 
@@ -1549,15 +1532,15 @@
     r.killAllPreviewNotes = function() {
       while (previewNotes.length > 0) {
         var rtNote = previewNotes.pop();
-        var inst = this._song._instruments.getObjById(rtNote._target);
+        for (var targetIdx = 0; targetIdx < rtNote._targets.length; targetIdx++) {
+          var inst = this._song._instruments.getObjById(rtNote._targets[targetIdx]);
 
-        // TODO: this check will need to change when full track->instrument
-        // routing is implemented
-        if (notDefined(inst)) {
-          continue;
+          if (notDefined(inst)) {
+            continue;
+          }
+
+          inst.triggerRelease(rtNote._id, 0);
         }
-
-        inst.triggerRelease(rtNote._id, 0);
       }
 
       console.log("[Rhombus] - killed all preview notes");
@@ -1649,6 +1632,7 @@
     Tone.extend(Sampler, Tone.Instrument);
     r._addParamFunctions(Sampler);
     r._addGraphFunctions(Sampler);
+    r._addAudioNodeFunctions(Sampler);
 
     Sampler.prototype.setBuffers = function(bufferMap) {
       if (notDefined(bufferMap)) {
@@ -1858,6 +1842,7 @@
     Tone.extend(ToneInstrument, Tone.PolySynth);
     r._addGraphFunctions(ToneInstrument);
     r._addParamFunctions(ToneInstrument);
+    r._addAudioNodeFunctions(ToneInstrument);
 
     ToneInstrument.prototype.triggerAttack = function(id, pitch, delay, velocity) {
       // Don't play out-of-range notes
@@ -2304,6 +2289,7 @@
       ctr.prototype._normalizedObjectSet = normalizedObjectSet;
       r._addParamFunctions(ctr);
       r._addGraphFunctions(ctr);
+      r._addAudioNodeFunctions(ctr);
       ctr.prototype.toJSON = toJSON;
       ctr.prototype.isMaster = isMaster;
     }
@@ -3005,18 +2991,18 @@
       }
     };
 
-    r.RtNote = function(pitch, velocity, start, end, target) {
+    r.RtNote = function(pitch, velocity, start, end, targets) {
       r._newRtId(this);
       this._pitch    = (isNaN(pitch) || notDefined(pitch)) ? 60 : pitch;
       this._velocity = +velocity || 0.5;
       this._start    = start || 0;
       this._end      = end || 0;
-      this._target   = target;
+      this._targets  = targets;
 
       return this;
     };
 
-    r.Track = function(id) {
+    function Track(id) {
       if (isDefined(id)) {
         r._setId(this, id);
       } else {
@@ -3029,226 +3015,247 @@
       this._solo = false;
 
       // track structure data
-      this._target = undefined;
+      this._targets = [];
       this._playingNotes = {};
       this._playlist = {};
+
+      this._graphSetup(0, 0, 0, 1);
+    };
+    r._addGraphFunctions(Track);
+    r.Track = Track;
+
+    Track.prototype.setId = function(id) {
+      this._id = id;
     };
 
-    r.Track.prototype = {
+    Track.prototype.getName = function() {
+      return this._name;
+    };
 
-      setId: function(id) {
-        this._id = id;
-      },
-
-      getName: function() {
-        return this._name;
-      },
-
-      setName: function(name) {
-        if (notDefined(name)) {
-          return undefined;
-        }
-        else {
-          var oldValue = this._name;
-          this._name = name.toString();
-
-          var that = this;
-          r.Undo._addUndoAction(function() {
-            that._name = oldValue;
-          });
-
-          return this._name;
-        }
-      },
-
-      getMute: function() {
-        return this._mute;
-      },
-
-      setMute: function(mute) {
-        if (typeof mute !== "boolean") {
-          return undefined;
-        }
-
-        var oldMute = this._mute;
-        var that = this;
-        r.Undo._addUndoAction(function() {
-          that._mute = oldMute;
-        });
-
-        this._mute = mute;
-        return mute;
-      },
-
-      toggleMute: function() {
-        return this.setMute(!this.getMute());
-      },
-
-      getSolo: function() {
-        return this._solo;
-      },
-
-      setSolo: function(solo) {
-        if (typeof solo !== "boolean") {
-          return undefined;
-        }
-
-        var soloList = r._song._soloList;
-
-        var oldSolo = this._solo;
-        var oldSoloList = soloList.slice(0);
-        var that = this;
-        r.Undo._addUndoAction(function() {
-          that._solo = oldSolo;
-          r._song._soloList = oldSoloList;
-        });
-
-        // Get the index of the current track in the solo list
-        var index = soloList.indexOf(this._id);
-
-        // The track is solo'd and solo is 'false'
-        if (index > -1 && !solo) {
-          soloList.splice(index, 1);
-        }
-        // The track is not solo'd and solo is 'true'
-        else if (index < 0 && solo) {
-          soloList.push(this._id);
-        }
-
-        this._solo = solo;
-        return solo;
-      },
-
-      toggleSolo: function() {
-        return this.setSolo(!this.getSolo());
-      },
-
-      getPlaylist: function() {
-        return this._playlist;
-      },
-
-      // Determine if a playlist item exists that overlaps with the given range
-      checkOverlap: function(start, end) {
-        for (var itemId in this._playlist) {
-          var item = this._playlist[itemId];
-          var itemStart = item._start;
-          var itemEnd = item._start + item._length;
-
-          // TODO: verify and simplify this logic
-          if (start < itemStart && end > itemStart) {
-            return true;
-          }
-
-          if (start >= itemStart && end < itemEnd) {
-            return true;
-          }
-
-          if (start >= itemStart && start < itemEnd) {
-            return true;
-          }
-        }
-
-        // No overlapping items found
-        return false;
-      },
-
-      addToPlaylist: function(ptnId, start, length) {
-        // All arguments must be defined
-        if (notDefined(ptnId) || notDefined(start) || notDefined(length)) {
-          return undefined;
-        }
-
-        // Don't allow overlapping playlist items
-        if (this.checkOverlap(start, start+length)) {
-          return undefined;
-        }
-
-        // ptnId myst belong to an existing pattern
-        if (notDefined(r._song._patterns[ptnId])) {
-          return undefined;
-        }
-
-        var newItem = new r.PlaylistItem(this._id, ptnId, start, length);
-        this._playlist[newItem._id] = newItem;
-
-        var that = this;
-        r.Undo._addUndoAction(function() {
-          delete that._playlist[newItem._id];
-        });
-
-        return newItem._id;
-
-        // TODO: restore length checks
-      },
-
-      getPlaylistItemById: function(id) {
-        return this._playlist[id];
-      },
-
-      getPlaylistItemByTick: function(tick) {
-        var playlist = this._playlist;
-        for (var itemId in playlist) {
-          var item = playlist[itemId];
-          var itemEnd = item._start + item._length;
-          if (tick >= item._start && tick < itemEnd) {
-            return item;
-          }
-        }
-
-        // no item at this location
+    Track.prototype.setName = function(name) {
+      if (notDefined(name)) {
         return undefined;
-      },
+      }
+      else {
+        var oldValue = this._name;
+        this._name = name.toString();
 
-      removeFromPlaylist: function(itemId) {
-        console.log("[Rhombus] - deleting playlist item " + itemId);
-        itemId = itemId.toString();
-        if (!(itemId in this._playlist)) {
-          return undefined;
-        } else {
+        var that = this;
+        r.Undo._addUndoAction(function() {
+          that._name = oldValue;
+        });
 
-          var obj = this._playlist[itemId];
-          var that = this;
-          r.Undo._addUndoAction(function() {
-            that._playlist[itemId] = obj;
-          });
-
-          delete this._playlist[itemId.toString()];
-        }
-
-        return itemId;
-      },
-
-      toJSON: function() {
-        var toReturn = {};
-        toReturn._id = this._id;
-        toReturn._name = this._name;
-        toReturn._target = this._target;
-        toReturn._playlist = this._playlist;
-        return toReturn;
-      },
-
-      exportEvents: function() {
-        var events = new AVL();
-        var playlist = this._playlist;
-        for (var itemId in playlist) {
-          var srcPtn = r.getSong().getPatterns()[playlist[itemId]._ptnId];
-          var notes = srcPtn.getAllNotes();
-
-          for (var i = 0; i < notes.length; i++) {
-            var note  = notes[i];
-            var start = Math.round(note.getStart() + playlist[itemId]._start);
-            var end   = start + Math.round(note.getLength());
-            var vel   = Math.round(note.getVelocity() * 127);
-
-            // insert the note-on and note-off events
-            events.insert(start, [ 0x90, note.getPitch(), vel ]);
-            events.insert(end,   [ 0x80, note.getPitch(), 64 ]);
-          }
-        }
-
-        return events;
+        return this._name;
       }
     };
+
+    Track.prototype.getMute = function() {
+      return this._mute;
+    };
+
+    Track.prototype.setMute = function(mute) {
+      if (typeof mute !== "boolean") {
+        return undefined;
+      }
+
+      var oldMute = this._mute;
+      var that = this;
+      r.Undo._addUndoAction(function() {
+        that._mute = oldMute;
+      });
+
+      this._mute = mute;
+      return mute;
+    };
+
+    Track.prototype.toggleMute = function() {
+      return this.setMute(!this.getMute());
+    };
+
+    Track.prototype.getSolo = function() {
+      return this._solo;
+    };
+
+    Track.prototype.setSolo = function(solo) {
+      if (typeof solo !== "boolean") {
+        return undefined;
+      }
+
+      var soloList = r._song._soloList;
+
+      var oldSolo = this._solo;
+      var oldSoloList = soloList.slice(0);
+      var that = this;
+      r.Undo._addUndoAction(function() {
+        that._solo = oldSolo;
+        r._song._soloList = oldSoloList;
+      });
+
+      // Get the index of the current track in the solo list
+      var index = soloList.indexOf(this._id);
+
+      // The track is solo'd and solo is 'false'
+      if (index > -1 && !solo) {
+        soloList.splice(index, 1);
+      }
+      // The track is not solo'd and solo is 'true'
+      else if (index < 0 && solo) {
+        soloList.push(this._id);
+      }
+
+      this._solo = solo;
+      return solo;
+    };
+
+    Track.prototype.toggleSolo =function() {
+      return this.setSolo(!this.getSolo());
+    };
+
+    Track.prototype.getPlaylist =function() {
+      return this._playlist;
+    };
+
+    // Determine if a playlist item exists that overlaps with the given range
+    Track.prototype.checkOverlap = function(start, end) {
+      for (var itemId in this._playlist) {
+        var item = this._playlist[itemId];
+        var itemStart = item._start;
+        var itemEnd = item._start + item._length;
+
+        // TODO: verify and simplify this logic
+        if (start < itemStart && end > itemStart) {
+          return true;
+        }
+
+        if (start >= itemStart && end < itemEnd) {
+          return true;
+        }
+
+        if (start >= itemStart && start < itemEnd) {
+          return true;
+        }
+      }
+
+      // No overlapping items found
+      return false;
+    };
+
+    Track.prototype.addToPlaylist = function(ptnId, start, length) {
+      // All arguments must be defined
+      if (notDefined(ptnId) || notDefined(start) || notDefined(length)) {
+        return undefined;
+      }
+
+      // Don't allow overlapping playlist items
+      if (this.checkOverlap(start, start+length)) {
+        return undefined;
+      }
+
+      // ptnId myst belong to an existing pattern
+      if (notDefined(r._song._patterns[ptnId])) {
+        return undefined;
+      }
+
+      var newItem = new r.PlaylistItem(this._id, ptnId, start, length);
+      this._playlist[newItem._id] = newItem;
+
+      var that = this;
+      r.Undo._addUndoAction(function() {
+        delete that._playlist[newItem._id];
+      });
+
+      return newItem._id;
+
+      // TODO: restore length checks
+    };
+
+    Track.prototype.getPlaylistItemById = function(id) {
+      return this._playlist[id];
+    };
+
+    Track.prototype.getPlaylistItemByTick = function(tick) {
+      var playlist = this._playlist;
+      for (var itemId in playlist) {
+        var item = playlist[itemId];
+        var itemEnd = item._start + item._length;
+        if (tick >= item._start && tick < itemEnd) {
+          return item;
+        }
+      }
+
+      // no item at this location
+      return undefined;
+    };
+
+    Track.prototype.removeFromPlaylist = function(itemId) {
+      console.log("[Rhombus] - deleting playlist item " + itemId);
+      itemId = itemId.toString();
+      if (!(itemId in this._playlist)) {
+        return undefined;
+      } else {
+
+        var obj = this._playlist[itemId];
+        var that = this;
+        r.Undo._addUndoAction(function() {
+          that._playlist[itemId] = obj;
+        });
+
+        delete this._playlist[itemId.toString()];
+      }
+
+      return itemId;
+    };
+
+    Track.prototype.toJSON = function() {
+      var toReturn = {};
+      toReturn._id = this._id;
+      toReturn._name = this._name;
+      toReturn._targets = this._targets;
+      toReturn._playlist = this._playlist;
+      return toReturn;
+    };
+
+    Track.prototype.exportEvents = function() {
+      var events = new AVL();
+      var playlist = this._playlist;
+      for (var itemId in playlist) {
+        var srcPtn = r.getSong().getPatterns()[playlist[itemId]._ptnId];
+        var notes = srcPtn.getAllNotes();
+
+        for (var i = 0; i < notes.length; i++) {
+          var note  = notes[i];
+          var start = Math.round(note.getStart() + playlist[itemId]._start);
+          var end   = start + Math.round(note.getLength());
+          var vel   = Math.round(note.getVelocity() * 127);
+
+          // insert the note-on and note-off events
+          events.insert(start, [ 0x90, note.getPitch(), vel ]);
+          events.insert(end,   [ 0x80, note.getPitch(), 64 ]);
+        }
+      }
+
+      return events;
+    };
+
+    Track.prototype._internalGraphConnect = function(output, b, bInput) {
+      if (b.isInstrument()) {
+        this._targets.push(b._id);
+      } else {
+        // TODO: effect automation here
+      }
+    };
+
+    Track.prototype._internalGraphDisconnect = function(output, b, bInput) {
+      if (b.isInstrument()) {
+        var idx = this._targets.indexOf(b._id);
+        if (idx >= 0) {
+          this._targets.splice(idx, 1);
+        }
+      } else {
+        // TODO: effect automation here
+      }
+    };
+
   };
 })(this.Rhombus);
 
@@ -3400,12 +3407,14 @@
           // TODO: find a more robust way to terminate playing notes
           for (var rtNoteId in this._playingNotes) {
             var note = this._playingNotes[rtNoteId];
-            r._song._instruments.getObjById(track._target).triggerRelease(rtNoteId, 0);
+
+            var instrs = r._song._instruments;
+            for (var targetIdx = 0; targetIdx < track._targets.length; targetIdx++) {
+              instrs.getObjById(track._targets[targetIdx]).triggerRelease(rtNoteId, 0);
+            }
+
             delete this._playingNotes[rtNoteId];
           }
-
-          // TODO: Figure out why this doesn't work
-          //r.removeInstrument(track._target);
 
           // Remove the track from the solo list, if it's soloed
           var index = r._song._soloList.indexOf(track._id);
@@ -3523,7 +3532,10 @@
         var newTrack = new this.Track(trkId);
 
         newTrack._name = track._name;
-        newTrack._target = +track._target;
+        newTrack._targets = track._targets;
+        for (var targetIdx = 0; targetIdx < newTrack._targets.length; targetIdx++) {
+          newTrack._targets[targetIdx] = +(newTrack._targets[targetIdx]);
+        }
 
         for (var itemId in playlist) {
           var item = playlist[itemId];
@@ -3666,7 +3678,10 @@
 
           if (end <= scheduleEndTime) {
             var delay = end - curTime;
-            r._song._instruments.getObjById(rtNote._target).triggerRelease(rtNote._id, delay);
+            var instrs = r._song._instruments;
+            for (var targetIdx = 0; targetIdx < rtNote._targets.length; targetIdx++) {
+              instrs.getObjById(rtNote._targets[targetIdx]).triggerRelease(rtNote._id, delay);
+            }
             delete playingNotes[rtNoteId];
           }
         }
@@ -3709,12 +3724,14 @@
                                         note.getVelocity(),
                                         startTime,
                                         endTime,
-                                        track._target);
+                                        track._targets);
 
               playingNotes[rtNote._id] = rtNote;
 
-              var instrument = r._song._instruments.getObjById(track._target);
-              instrument.triggerAttack(rtNote._id, note.getPitch(), delay, note.getVelocity());
+              for (var targetIdx = 0; targetIdx < track._targets.length; targetIdx++) {
+                var instrument = r._song._instruments.getObjById(track._targets[targetIdx]);
+                instrument.triggerAttack(rtNote._id, note.getPitch(), delay, note.getVelocity());
+              }
             }
           }
         }
@@ -4603,5 +4620,50 @@
         navigator.requestMIDIAccess().then(onMidiSuccess, onMidiFailure);
       }
     };
+  };
+})(this.Rhombus);
+
+//! rhombus.audionode.js
+//! authors: Spencer Phippen, Tim Grant
+//! license: MIT
+(function (Rhombus) {
+
+  // Code shared between instruments and nodes.
+
+  Rhombus._audioNodeSetup = function(r) {
+
+    function internalGraphConnect(output, b, bInput) {
+      // TODO: use the slots when connecting
+      var type = this._graphOutputs[output].type;
+      if (type === "audio") {
+        this.connect(b);
+      } else if (type === "control") {
+        // TODO: implement control routing
+      }
+    }
+
+    function internalGraphDisconnect(output, b, bInput) {
+      // TODO: use the slots when disconnecting
+      var type = this._graphOutputs[output].type;
+      if (type === "audio") {
+        // TODO: this should be replaced in such a way that we
+        // don't break all the outgoing connections every time we
+        // disconnect from one thing. Put gain nodes in the middle
+        // or something.
+        this.disconnect();
+        var that = this;
+        this._graphOutputs[output].to.forEach(function(port) {
+          that.connect(r.graphLookup(port.node));
+        });
+      } else if (type === "control") {
+        // TODO: implement control routing
+      }
+    }
+
+    r._addAudioNodeFunctions = function(ctr) {
+      ctr.prototype._internalGraphConnect = internalGraphConnect;
+      ctr.prototype._internalGraphDisconnect = internalGraphDisconnect;
+    };
+
   };
 })(this.Rhombus);

--- a/build/rhombus.js
+++ b/build/rhombus.js
@@ -874,6 +874,10 @@
       if (isDefined(instr)) {
         return instr;
       }
+      var track = r._song._tracks.getObjById(id);
+      if (isDefined(track)) {
+        return track;
+      }
       return r._song._effects[id];
     }
     r.graphLookup = graphLookup;
@@ -1160,19 +1164,7 @@
       });
     };
 
-    r.getNodeById = function(nodeId) {
-      var effect = this._song._effects[nodeId];
-      var inst   = this._song._instruments.getObjById(nodeId);
-
-      if (isDefined(effect)) {
-        return effect;
-      }
-      if (isDefined(inst)) {
-        return inst;
-      }
-
-      return undefined;
-    };
+    r.getNodeById = graphLookup;
 
   };
 })(this.Rhombus);

--- a/build/rhombus.js
+++ b/build/rhombus.js
@@ -1089,6 +1089,18 @@
       }
     }
 
+    function isEffect() {
+      return this._graphType === "effect";
+    }
+
+    function isInstrument() {
+      return this._graphType === "instrument";
+    }
+
+    function isTrack() {
+      return this._graphType === "track";
+    }
+
     r._addGraphFunctions = function(ctr) {
       ctr.prototype._graphSetup = graphSetup;
       ctr.prototype.graphInputs = graphInputs;
@@ -1102,6 +1114,10 @@
       ctr.prototype.setGraphX = setGraphX;
       ctr.prototype.graphY = graphY;
       ctr.prototype.setGraphY = setGraphY;
+      
+      ctr.prototype.isEffect = isEffect;
+      ctr.prototype.isInstrument = isInstrument;
+      ctr.prototype.isTrack = isTrack;
     };
 
     r.getMaster = function() {
@@ -1374,8 +1390,7 @@
       });
       this._song._instruments.addObj(instr, idx);
 
-      instr.isInstrument = function() { return true; };
-      instr.isEffect = function() { return false; };
+      instr._graphType = "instrument";
 
       return instr._id;
     };
@@ -2236,8 +2251,7 @@
 
       this._song._effects[eff._id] = eff;
 
-      eff.isInstrument = function() { return false; };
-      eff.isEffect = function() { return true; };
+      eff._graphType = "effect";
 
       return eff._id;
     }
@@ -3023,6 +3037,8 @@
     };
     r._addGraphFunctions(Track);
     r.Track = Track;
+
+    Track.prototype._graphType = "track";
 
     Track.prototype.setId = function(id) {
       this._id = id;

--- a/demos/timebase-demo.html
+++ b/demos/timebase-demo.html
@@ -59,7 +59,7 @@ instr.normalizedSetByName("volume", 0.6);
 
 var trackId = rhomb._song.addTrack();
 var track = rhomb.getSong().getTracks().getObjById(trackId);
-track._target = instrId;
+track.graphConnect(0, instr, 0);
 track.addToPlaylist(patId, 0, 3840);
 
 ins(60, 0, 240);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -24,6 +24,7 @@ gulp.task("make", function() {
     "src/rhombus.undo.js",
     "src/rhombus.record.js",
     "src/rhombus.midi.js",
+    "src/rhombus.audionode.js",
     ])
     .pipe(concat("rhombus.js"))
     .pipe(gulp.dest("build"))

--- a/src/rhombus.audionode.js
+++ b/src/rhombus.audionode.js
@@ -1,0 +1,44 @@
+//! rhombus.audionode.js
+//! authors: Spencer Phippen, Tim Grant
+//! license: MIT
+(function (Rhombus) {
+
+  // Code shared between instruments and nodes.
+
+  Rhombus._audioNodeSetup = function(r) {
+
+    function internalGraphConnect(output, b, bInput) {
+      // TODO: use the slots when connecting
+      var type = this._graphOutputs[output].type;
+      if (type === "audio") {
+        this.connect(b);
+      } else if (type === "control") {
+        // TODO: implement control routing
+      }
+    }
+
+    function internalGraphDisconnect(output, b, bInput) {
+      // TODO: use the slots when disconnecting
+      var type = this._graphOutputs[output].type;
+      if (type === "audio") {
+        // TODO: this should be replaced in such a way that we
+        // don't break all the outgoing connections every time we
+        // disconnect from one thing. Put gain nodes in the middle
+        // or something.
+        this.disconnect();
+        var that = this;
+        this._graphOutputs[output].to.forEach(function(port) {
+          that.connect(r.graphLookup(port.node));
+        });
+      } else if (type === "control") {
+        // TODO: implement control routing
+      }
+    }
+
+    r._addAudioNodeFunctions = function(ctr) {
+      ctr.prototype._internalGraphConnect = internalGraphConnect;
+      ctr.prototype._internalGraphDisconnect = internalGraphDisconnect;
+    };
+
+  };
+})(this.Rhombus);

--- a/src/rhombus.effect.js
+++ b/src/rhombus.effect.js
@@ -162,6 +162,7 @@
       ctr.prototype._normalizedObjectSet = normalizedObjectSet;
       r._addParamFunctions(ctr);
       r._addGraphFunctions(ctr);
+      r._addAudioNodeFunctions(ctr);
       ctr.prototype.toJSON = toJSON;
       ctr.prototype.isMaster = isMaster;
     }

--- a/src/rhombus.effect.js
+++ b/src/rhombus.effect.js
@@ -109,8 +109,7 @@
 
       this._song._effects[eff._id] = eff;
 
-      eff.isInstrument = function() { return false; };
-      eff.isEffect = function() { return true; };
+      eff._graphType = "effect";
 
       return eff._id;
     }

--- a/src/rhombus.graph.js
+++ b/src/rhombus.graph.js
@@ -162,13 +162,7 @@
       outputObj.to.push(new Port(b._id, bInput));
       inputObj.from.push(new Port(this._id, output));
 
-      // TODO: use the slots when connecting
-      var type = outputObj.type;
-      if (type === "audio") {
-        this.connect(b);
-      } else if (type === "control") {
-        // TODO: implement control routing
-      }
+      this._internalGraphConnect(output, b, bInput);
       return true;
     };
 
@@ -215,21 +209,7 @@
       outputObj.to.splice(outputPortIdx, 1);
       inputObj.from.splice(inputPortIdx, 1);
 
-      // TODO: use the slots when disconnecting
-      var type = outputObj.type;
-      if (type === "audio") {
-        // TODO: this should be replaced in such a way that we
-        // don't break all the outgoing connections every time we
-        // disconnect from one thing. Put gain nodes in the middle
-        // or something.
-        this.disconnect();
-        var that = this;
-        outputObj.to.forEach(function (port) {
-          that.connect(graphLookup(port.node));
-        });
-      } else if (type === "control") {
-        // TODO: implement control routing
-      }
+      this._internalGraphDisconnect(output, b, bInput);
     }
 
     function graphX() {

--- a/src/rhombus.graph.js
+++ b/src/rhombus.graph.js
@@ -275,6 +275,18 @@
       }
     }
 
+    function isEffect() {
+      return this._graphType === "effect";
+    }
+
+    function isInstrument() {
+      return this._graphType === "instrument";
+    }
+
+    function isTrack() {
+      return this._graphType === "track";
+    }
+
     r._addGraphFunctions = function(ctr) {
       ctr.prototype._graphSetup = graphSetup;
       ctr.prototype.graphInputs = graphInputs;
@@ -288,6 +300,10 @@
       ctr.prototype.setGraphX = setGraphX;
       ctr.prototype.graphY = graphY;
       ctr.prototype.setGraphY = setGraphY;
+      
+      ctr.prototype.isEffect = isEffect;
+      ctr.prototype.isInstrument = isInstrument;
+      ctr.prototype.isTrack = isTrack;
     };
 
     r.getMaster = function() {

--- a/src/rhombus.graph.js
+++ b/src/rhombus.graph.js
@@ -60,6 +60,10 @@
       if (isDefined(instr)) {
         return instr;
       }
+      var track = r._song._tracks.getObjById(id);
+      if (isDefined(track)) {
+        return track;
+      }
       return r._song._effects[id];
     }
     r.graphLookup = graphLookup;
@@ -346,19 +350,7 @@
       });
     };
 
-    r.getNodeById = function(nodeId) {
-      var effect = this._song._effects[nodeId];
-      var inst   = this._song._instruments.getObjById(nodeId);
-
-      if (isDefined(effect)) {
-        return effect;
-      }
-      if (isDefined(inst)) {
-        return inst;
-      }
-
-      return undefined;
-    };
+    r.getNodeById = graphLookup;
 
   };
 })(this.Rhombus);

--- a/src/rhombus.header.js
+++ b/src/rhombus.header.js
@@ -77,6 +77,7 @@
     root.Rhombus._songSetup(this);
     root.Rhombus._paramSetup(this);
     root.Rhombus._recordSetup(this);
+    root.Rhombus._audioNodeSetup(this);
 
     // Instruments
     root.Rhombus._instrumentSetup(this);

--- a/src/rhombus.instrument.js
+++ b/src/rhombus.instrument.js
@@ -58,8 +58,7 @@
       });
       this._song._instruments.addObj(instr, idx);
 
-      instr.isInstrument = function() { return true; };
-      instr.isEffect = function() { return false; };
+      instr._graphType = "instrument";
 
       return instr._id;
     };

--- a/src/rhombus.instrument.js
+++ b/src/rhombus.instrument.js
@@ -183,9 +183,11 @@
       for (var i = previewNotes.length - 1; i >=0; i--) {
         var rtNote = previewNotes[i];
         if (rtNote._pitch === pitch) {
-          var inst = this._song._instruments.getObjById(rtNote._target);
-
-          if (isDefined(inst)) {
+          for (var targetIdx = 0; targetIdx < rtNote._targets.length; targetIdx++) {
+            var inst = this._song._instruments.getObjById(rtNote._targets[targetIdx]);
+            if (notDefined(inst)) {
+              continue;
+            }
             inst.triggerRelease(rtNote._id, 0);
           }
 
@@ -214,15 +216,15 @@
     r.killAllPreviewNotes = function() {
       while (previewNotes.length > 0) {
         var rtNote = previewNotes.pop();
-        var inst = this._song._instruments.getObjById(rtNote._target);
+        for (var targetIdx = 0; targetIdx < rtNote._targets.length; targetIdx++) {
+          var inst = this._song._instruments.getObjById(rtNote._targets[targetIdx]);
 
-        // TODO: this check will need to change when full track->instrument
-        // routing is implemented
-        if (notDefined(inst)) {
-          continue;
+          if (notDefined(inst)) {
+            continue;
+          }
+
+          inst.triggerRelease(rtNote._id, 0);
         }
-
-        inst.triggerRelease(rtNote._id, 0);
       }
 
       console.log("[Rhombus] - killed all preview notes");

--- a/src/rhombus.instrument.sampler.js
+++ b/src/rhombus.instrument.sampler.js
@@ -82,6 +82,7 @@
     Tone.extend(Sampler, Tone.Instrument);
     r._addParamFunctions(Sampler);
     r._addGraphFunctions(Sampler);
+    r._addAudioNodeFunctions(Sampler);
 
     Sampler.prototype.setBuffers = function(bufferMap) {
       if (notDefined(bufferMap)) {

--- a/src/rhombus.instrument.tone.js
+++ b/src/rhombus.instrument.tone.js
@@ -51,6 +51,7 @@
     Tone.extend(ToneInstrument, Tone.PolySynth);
     r._addGraphFunctions(ToneInstrument);
     r._addParamFunctions(ToneInstrument);
+    r._addAudioNodeFunctions(ToneInstrument);
 
     ToneInstrument.prototype.triggerAttack = function(id, pitch, delay, velocity) {
       // Don't play out-of-range notes

--- a/src/rhombus.song.js
+++ b/src/rhombus.song.js
@@ -146,12 +146,14 @@
           // TODO: find a more robust way to terminate playing notes
           for (var rtNoteId in this._playingNotes) {
             var note = this._playingNotes[rtNoteId];
-            r._song._instruments.getObjById(track._target).triggerRelease(rtNoteId, 0);
+
+            var instrs = r._song._instruments;
+            for (var targetIdx = 0; targetIdx < track._targets.length; targetIdx++) {
+              instrs.getObjById(track._targets[targetIdx]).triggerRelease(rtNoteId, 0);
+            }
+
             delete this._playingNotes[rtNoteId];
           }
-
-          // TODO: Figure out why this doesn't work
-          //r.removeInstrument(track._target);
 
           // Remove the track from the solo list, if it's soloed
           var index = r._song._soloList.indexOf(track._id);
@@ -269,7 +271,10 @@
         var newTrack = new this.Track(trkId);
 
         newTrack._name = track._name;
-        newTrack._target = +track._target;
+        newTrack._targets = track._targets;
+        for (var targetIdx = 0; targetIdx < newTrack._targets.length; targetIdx++) {
+          newTrack._targets[targetIdx] = +(newTrack._targets[targetIdx]);
+        }
 
         for (var itemId in playlist) {
           var item = playlist[itemId];

--- a/src/rhombus.time.js
+++ b/src/rhombus.time.js
@@ -76,7 +76,10 @@
 
           if (end <= scheduleEndTime) {
             var delay = end - curTime;
-            r._song._instruments.getObjById(rtNote._target).triggerRelease(rtNote._id, delay);
+            var instrs = r._song._instruments;
+            for (var targetIdx = 0; targetIdx < rtNote._targets.length; targetIdx++) {
+              instrs.getObjById(rtNote._targets[targetIdx]).triggerRelease(rtNote._id, delay);
+            }
             delete playingNotes[rtNoteId];
           }
         }
@@ -119,12 +122,14 @@
                                         note.getVelocity(),
                                         startTime,
                                         endTime,
-                                        track._target);
+                                        track._targets);
 
               playingNotes[rtNote._id] = rtNote;
 
-              var instrument = r._song._instruments.getObjById(track._target);
-              instrument.triggerAttack(rtNote._id, note.getPitch(), delay, note.getVelocity());
+              for (var targetIdx = 0; targetIdx < track._targets.length; targetIdx++) {
+                var instrument = r._song._instruments.getObjById(track._targets[targetIdx]);
+                instrument.triggerAttack(rtNote._id, note.getPitch(), delay, note.getVelocity());
+              }
             }
           }
         }

--- a/src/rhombus.track.js
+++ b/src/rhombus.track.js
@@ -109,6 +109,8 @@
     r._addGraphFunctions(Track);
     r.Track = Track;
 
+    Track.prototype._graphType = "track";
+
     Track.prototype.setId = function(id) {
       this._id = id;
     };

--- a/src/rhombus.track.js
+++ b/src/rhombus.track.js
@@ -76,18 +76,18 @@
       }
     };
 
-    r.RtNote = function(pitch, velocity, start, end, target) {
+    r.RtNote = function(pitch, velocity, start, end, targets) {
       r._newRtId(this);
       this._pitch    = (isNaN(pitch) || notDefined(pitch)) ? 60 : pitch;
       this._velocity = +velocity || 0.5;
       this._start    = start || 0;
       this._end      = end || 0;
-      this._target   = target;
+      this._targets  = targets;
 
       return this;
     };
 
-    r.Track = function(id) {
+    function Track(id) {
       if (isDefined(id)) {
         r._setId(this, id);
       } else {
@@ -100,225 +100,246 @@
       this._solo = false;
 
       // track structure data
-      this._target = undefined;
+      this._targets = [];
       this._playingNotes = {};
       this._playlist = {};
+
+      this._graphSetup(0, 0, 0, 1);
+    };
+    r._addGraphFunctions(Track);
+    r.Track = Track;
+
+    Track.prototype.setId = function(id) {
+      this._id = id;
     };
 
-    r.Track.prototype = {
+    Track.prototype.getName = function() {
+      return this._name;
+    };
 
-      setId: function(id) {
-        this._id = id;
-      },
-
-      getName: function() {
-        return this._name;
-      },
-
-      setName: function(name) {
-        if (notDefined(name)) {
-          return undefined;
-        }
-        else {
-          var oldValue = this._name;
-          this._name = name.toString();
-
-          var that = this;
-          r.Undo._addUndoAction(function() {
-            that._name = oldValue;
-          });
-
-          return this._name;
-        }
-      },
-
-      getMute: function() {
-        return this._mute;
-      },
-
-      setMute: function(mute) {
-        if (typeof mute !== "boolean") {
-          return undefined;
-        }
-
-        var oldMute = this._mute;
-        var that = this;
-        r.Undo._addUndoAction(function() {
-          that._mute = oldMute;
-        });
-
-        this._mute = mute;
-        return mute;
-      },
-
-      toggleMute: function() {
-        return this.setMute(!this.getMute());
-      },
-
-      getSolo: function() {
-        return this._solo;
-      },
-
-      setSolo: function(solo) {
-        if (typeof solo !== "boolean") {
-          return undefined;
-        }
-
-        var soloList = r._song._soloList;
-
-        var oldSolo = this._solo;
-        var oldSoloList = soloList.slice(0);
-        var that = this;
-        r.Undo._addUndoAction(function() {
-          that._solo = oldSolo;
-          r._song._soloList = oldSoloList;
-        });
-
-        // Get the index of the current track in the solo list
-        var index = soloList.indexOf(this._id);
-
-        // The track is solo'd and solo is 'false'
-        if (index > -1 && !solo) {
-          soloList.splice(index, 1);
-        }
-        // The track is not solo'd and solo is 'true'
-        else if (index < 0 && solo) {
-          soloList.push(this._id);
-        }
-
-        this._solo = solo;
-        return solo;
-      },
-
-      toggleSolo: function() {
-        return this.setSolo(!this.getSolo());
-      },
-
-      getPlaylist: function() {
-        return this._playlist;
-      },
-
-      // Determine if a playlist item exists that overlaps with the given range
-      checkOverlap: function(start, end) {
-        for (var itemId in this._playlist) {
-          var item = this._playlist[itemId];
-          var itemStart = item._start;
-          var itemEnd = item._start + item._length;
-
-          // TODO: verify and simplify this logic
-          if (start < itemStart && end > itemStart) {
-            return true;
-          }
-
-          if (start >= itemStart && end < itemEnd) {
-            return true;
-          }
-
-          if (start >= itemStart && start < itemEnd) {
-            return true;
-          }
-        }
-
-        // No overlapping items found
-        return false;
-      },
-
-      addToPlaylist: function(ptnId, start, length) {
-        // All arguments must be defined
-        if (notDefined(ptnId) || notDefined(start) || notDefined(length)) {
-          return undefined;
-        }
-
-        // Don't allow overlapping playlist items
-        if (this.checkOverlap(start, start+length)) {
-          return undefined;
-        }
-
-        // ptnId myst belong to an existing pattern
-        if (notDefined(r._song._patterns[ptnId])) {
-          return undefined;
-        }
-
-        var newItem = new r.PlaylistItem(this._id, ptnId, start, length);
-        this._playlist[newItem._id] = newItem;
-
-        var that = this;
-        r.Undo._addUndoAction(function() {
-          delete that._playlist[newItem._id];
-        });
-
-        return newItem._id;
-
-        // TODO: restore length checks
-      },
-
-      getPlaylistItemById: function(id) {
-        return this._playlist[id];
-      },
-
-      getPlaylistItemByTick: function(tick) {
-        var playlist = this._playlist;
-        for (var itemId in playlist) {
-          var item = playlist[itemId];
-          var itemEnd = item._start + item._length;
-          if (tick >= item._start && tick < itemEnd) {
-            return item;
-          }
-        }
-
-        // no item at this location
+    Track.prototype.setName = function(name) {
+      if (notDefined(name)) {
         return undefined;
-      },
+      }
+      else {
+        var oldValue = this._name;
+        this._name = name.toString();
 
-      removeFromPlaylist: function(itemId) {
-        console.log("[Rhombus] - deleting playlist item " + itemId);
-        itemId = itemId.toString();
-        if (!(itemId in this._playlist)) {
-          return undefined;
-        } else {
+        var that = this;
+        r.Undo._addUndoAction(function() {
+          that._name = oldValue;
+        });
 
-          var obj = this._playlist[itemId];
-          var that = this;
-          r.Undo._addUndoAction(function() {
-            that._playlist[itemId] = obj;
-          });
-
-          delete this._playlist[itemId.toString()];
-        }
-
-        return itemId;
-      },
-
-      toJSON: function() {
-        var toReturn = {};
-        toReturn._id = this._id;
-        toReturn._name = this._name;
-        toReturn._target = this._target;
-        toReturn._playlist = this._playlist;
-        return toReturn;
-      },
-
-      exportEvents: function() {
-        var events = new AVL();
-        var playlist = this._playlist;
-        for (var itemId in playlist) {
-          var srcPtn = r.getSong().getPatterns()[playlist[itemId]._ptnId];
-          var notes = srcPtn.getAllNotes();
-
-          for (var i = 0; i < notes.length; i++) {
-            var note  = notes[i];
-            var start = Math.round(note.getStart() + playlist[itemId]._start);
-            var end   = start + Math.round(note.getLength());
-            var vel   = Math.round(note.getVelocity() * 127);
-
-            // insert the note-on and note-off events
-            events.insert(start, [ 0x90, note.getPitch(), vel ]);
-            events.insert(end,   [ 0x80, note.getPitch(), 64 ]);
-          }
-        }
-
-        return events;
+        return this._name;
       }
     };
+
+    Track.prototype.getMute = function() {
+      return this._mute;
+    };
+
+    Track.prototype.setMute = function(mute) {
+      if (typeof mute !== "boolean") {
+        return undefined;
+      }
+
+      var oldMute = this._mute;
+      var that = this;
+      r.Undo._addUndoAction(function() {
+        that._mute = oldMute;
+      });
+
+      this._mute = mute;
+      return mute;
+    };
+
+    Track.prototype.toggleMute = function() {
+      return this.setMute(!this.getMute());
+    };
+
+    Track.prototype.getSolo = function() {
+      return this._solo;
+    };
+
+    Track.prototype.setSolo = function(solo) {
+      if (typeof solo !== "boolean") {
+        return undefined;
+      }
+
+      var soloList = r._song._soloList;
+
+      var oldSolo = this._solo;
+      var oldSoloList = soloList.slice(0);
+      var that = this;
+      r.Undo._addUndoAction(function() {
+        that._solo = oldSolo;
+        r._song._soloList = oldSoloList;
+      });
+
+      // Get the index of the current track in the solo list
+      var index = soloList.indexOf(this._id);
+
+      // The track is solo'd and solo is 'false'
+      if (index > -1 && !solo) {
+        soloList.splice(index, 1);
+      }
+      // The track is not solo'd and solo is 'true'
+      else if (index < 0 && solo) {
+        soloList.push(this._id);
+      }
+
+      this._solo = solo;
+      return solo;
+    };
+
+    Track.prototype.toggleSolo =function() {
+      return this.setSolo(!this.getSolo());
+    };
+
+    Track.prototype.getPlaylist =function() {
+      return this._playlist;
+    };
+
+    // Determine if a playlist item exists that overlaps with the given range
+    Track.prototype.checkOverlap = function(start, end) {
+      for (var itemId in this._playlist) {
+        var item = this._playlist[itemId];
+        var itemStart = item._start;
+        var itemEnd = item._start + item._length;
+
+        // TODO: verify and simplify this logic
+        if (start < itemStart && end > itemStart) {
+          return true;
+        }
+
+        if (start >= itemStart && end < itemEnd) {
+          return true;
+        }
+
+        if (start >= itemStart && start < itemEnd) {
+          return true;
+        }
+      }
+
+      // No overlapping items found
+      return false;
+    };
+
+    Track.prototype.addToPlaylist = function(ptnId, start, length) {
+      // All arguments must be defined
+      if (notDefined(ptnId) || notDefined(start) || notDefined(length)) {
+        return undefined;
+      }
+
+      // Don't allow overlapping playlist items
+      if (this.checkOverlap(start, start+length)) {
+        return undefined;
+      }
+
+      // ptnId myst belong to an existing pattern
+      if (notDefined(r._song._patterns[ptnId])) {
+        return undefined;
+      }
+
+      var newItem = new r.PlaylistItem(this._id, ptnId, start, length);
+      this._playlist[newItem._id] = newItem;
+
+      var that = this;
+      r.Undo._addUndoAction(function() {
+        delete that._playlist[newItem._id];
+      });
+
+      return newItem._id;
+
+      // TODO: restore length checks
+    };
+
+    Track.prototype.getPlaylistItemById = function(id) {
+      return this._playlist[id];
+    };
+
+    Track.prototype.getPlaylistItemByTick = function(tick) {
+      var playlist = this._playlist;
+      for (var itemId in playlist) {
+        var item = playlist[itemId];
+        var itemEnd = item._start + item._length;
+        if (tick >= item._start && tick < itemEnd) {
+          return item;
+        }
+      }
+
+      // no item at this location
+      return undefined;
+    };
+
+    Track.prototype.removeFromPlaylist = function(itemId) {
+      console.log("[Rhombus] - deleting playlist item " + itemId);
+      itemId = itemId.toString();
+      if (!(itemId in this._playlist)) {
+        return undefined;
+      } else {
+
+        var obj = this._playlist[itemId];
+        var that = this;
+        r.Undo._addUndoAction(function() {
+          that._playlist[itemId] = obj;
+        });
+
+        delete this._playlist[itemId.toString()];
+      }
+
+      return itemId;
+    };
+
+    Track.prototype.toJSON = function() {
+      var toReturn = {};
+      toReturn._id = this._id;
+      toReturn._name = this._name;
+      toReturn._targets = this._targets;
+      toReturn._playlist = this._playlist;
+      return toReturn;
+    };
+
+    Track.prototype.exportEvents = function() {
+      var events = new AVL();
+      var playlist = this._playlist;
+      for (var itemId in playlist) {
+        var srcPtn = r.getSong().getPatterns()[playlist[itemId]._ptnId];
+        var notes = srcPtn.getAllNotes();
+
+        for (var i = 0; i < notes.length; i++) {
+          var note  = notes[i];
+          var start = Math.round(note.getStart() + playlist[itemId]._start);
+          var end   = start + Math.round(note.getLength());
+          var vel   = Math.round(note.getVelocity() * 127);
+
+          // insert the note-on and note-off events
+          events.insert(start, [ 0x90, note.getPitch(), vel ]);
+          events.insert(end,   [ 0x80, note.getPitch(), 64 ]);
+        }
+      }
+
+      return events;
+    };
+
+    Track.prototype._internalGraphConnect = function(output, b, bInput) {
+      if (b.isInstrument()) {
+        this._targets.push(b._id);
+      } else {
+        // TODO: effect automation here
+      }
+    };
+
+    Track.prototype._internalGraphDisconnect = function(output, b, bInput) {
+      if (b.isInstrument()) {
+        var idx = this._targets.indexOf(b._id);
+        if (idx >= 0) {
+          this._targets.splice(idx, 1);
+        }
+      } else {
+        // TODO: effect automation here
+      }
+    };
+
   };
 })(this.Rhombus);


### PR DESCRIPTION
Tracks now use the same interface as other graph objects (instruments, effects). They have one control output that provides notes to instruments and automation to instruments/effects (automation not yet implemented). As this breaks the external interface to track routing functionality (it used to be based on setting the "_target" property of the track object), I think it probably shouldn't be merged until the front end uses the new interface as well.
